### PR TITLE
Fix javadoc generation failing when using newer JDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,8 +60,6 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
                     <!--<testSource>1.8</testSource>-->
                     <!--<testTarget>1.8</testTarget>-->
                     <compilerArgument>-Xlint:none</compilerArgument>
@@ -97,7 +95,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -138,5 +136,10 @@
     
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <javaVersion>1.6</javaVersion>
+        <!-- These are also used by javadoc plugin, see MJAVADOC-562 -->
+        <maven.compiler.source>${javaVersion}</maven.compiler.source>
+        <maven.compiler.target>${javaVersion}</maven.compiler.target>
     </properties>
 </project>

--- a/src/org/benf/cfr/reader/bytecode/analysis/opgraph/op4rewriters/transformers/TryResourcesTransformerJ12.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/opgraph/op4rewriters/transformers/TryResourcesTransformerJ12.java
@@ -14,7 +14,7 @@ import org.benf.cfr.reader.bytecode.analysis.structured.statement.placeholder.En
 import org.benf.cfr.reader.bytecode.analysis.types.JavaTypeInstance;
 import org.benf.cfr.reader.bytecode.analysis.types.TypeConstants;
 import org.benf.cfr.reader.entities.ClassFile;
-import org.benf.cfr.reader.util.collections.Functional;;
+import org.benf.cfr.reader.util.collections.Functional;
 import org.benf.cfr.reader.util.functors.Predicate;
 
 import java.util.Collections;


### PR DESCRIPTION
Previously building with JDK 11 failed:
> The code being documented uses modules but the packages defined in https://docs.oracle.com/javase/6/docs/api/ are in the unnamed module.

The reason appears to be that the maven-javadoc-plugin did not use the
Java version against which the project is compiled. Switching to a newer
plugin version and setting the Java version as property solves this, see also
https://issues.apache.org/jira/browse/MJAVADOC-562.

I have verified that it works with JDK 8 (AdoptOpenJDK) and JDK 11. However, would you mind checking older versions as well in case you are using them?