### PR TITLE
Fix Eclipse compilation issue

### DIFF
--- a/src/org/benf/cfr/reader/bytecode/analysis/opgraph/op4rewriters/EnumClassRewriter.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/opgraph/op4rewriters/EnumClassRewriter.java
@@ -139,7 +139,7 @@ public class EnumClassRewriter {
 
         List<Pair<StaticVariable, AbstractConstructorInvokation>> entries = ListFactory.newList();
         for (Map.Entry<StaticVariable, CollectedEnumData<? extends AbstractConstructorInvokation>> entry : entryMap.entrySet()) {
-            entries.add(Pair.make(entry.getKey(), entry.getValue().getData()));
+            entries.add(Pair.<StaticVariable, AbstractConstructorInvokation>make(entry.getKey(), entry.getValue().getData()));
         }
         classFile.setDumpHelper(new ClassFileDumperEnum(state, entries));
 


### PR DESCRIPTION
Eclipse failed compiling the changed line of CFR source code, possibly due to an Eclipse specific compiler bug since `javac` could compile the code just fine.

![Eclipse compilation error](https://user-images.githubusercontent.com/11685886/72027148-3a15d980-327e-11ea-80d2-172415a658ea.png)

However, since `javac` can compile the code, I can understand if you decide to refuse merging this pull request.