### PR TITLE
Fix SUMMARY Sink implementations not receiving error information

### DIFF
--- a/src/org/benf/cfr/reader/PluginRunner.java
+++ b/src/org/benf/cfr/reader/PluginRunner.java
@@ -14,6 +14,7 @@ import org.benf.cfr.reader.util.functors.UnaryFunction;
 import org.benf.cfr.reader.util.getopt.Options;
 import org.benf.cfr.reader.util.getopt.OptionsImpl;
 import org.benf.cfr.reader.util.output.*;
+import org.benf.cfr.reader.util.output.MethodErrorCollector.SummaryDumperMethodErrorCollector;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -74,7 +75,7 @@ public class PluginRunner {
         }
 
         public Dumper getNewTopLevelDumper(JavaTypeInstance classType, SummaryDumper summaryDumper, TypeUsageInformation typeUsageInformation, IllegalIdentifierDump illegalIdentifierDump) {
-            return new StringStreamDumper(outBuffer, typeUsageInformation, options, this.illegalIdentifierDump);
+            return new StringStreamDumper(new SummaryDumperMethodErrorCollector(classType, summaryDumper), outBuffer, typeUsageInformation, options, this.illegalIdentifierDump);
         }
 
         /*

--- a/src/org/benf/cfr/reader/util/output/Dumper.java
+++ b/src/org/benf/cfr/reader/util/output/Dumper.java
@@ -10,7 +10,7 @@ import org.benf.cfr.reader.state.TypeUsageInformation;
 /*
  * NB: This interface is NOT an externally visible one, and is subject to change.
  */
-public interface Dumper {
+public interface Dumper extends MethodErrorCollector {
     /*
      * A dumper is initialised with knowledge of the types, so that two
      * dumpers can dump the same code with different import shortening.
@@ -51,6 +51,7 @@ public interface Dumper {
 
     void close();
 
+    @Override
     void addSummaryError(Method method, String s);
 
     boolean canEmitClass(JavaTypeInstance type);

--- a/src/org/benf/cfr/reader/util/output/MethodErrorCollector.java
+++ b/src/org/benf/cfr/reader/util/output/MethodErrorCollector.java
@@ -1,0 +1,23 @@
+package org.benf.cfr.reader.util.output;
+
+import org.benf.cfr.reader.bytecode.analysis.types.JavaTypeInstance;
+import org.benf.cfr.reader.entities.Method;
+
+public interface MethodErrorCollector {
+    void addSummaryError(Method method, String s);
+
+    static class SummaryDumperMethodErrorCollector implements MethodErrorCollector {
+        private final JavaTypeInstance type;
+        private final SummaryDumper summaryDumper;
+
+        public SummaryDumperMethodErrorCollector(JavaTypeInstance type, SummaryDumper summaryDumper) {
+            this.type = type;
+            this.summaryDumper = summaryDumper;
+        }
+
+        @Override
+        public void addSummaryError(Method method, String s) {
+            summaryDumper.notifyError(type, method, s);
+        }
+    }
+}

--- a/src/org/benf/cfr/reader/util/output/StringStreamDumper.java
+++ b/src/org/benf/cfr/reader/util/output/StringStreamDumper.java
@@ -5,14 +5,16 @@ import org.benf.cfr.reader.state.TypeUsageInformation;
 import org.benf.cfr.reader.util.getopt.Options;
 
 public class StringStreamDumper extends StreamDumper {
+    private final MethodErrorCollector methodErrorCollector;
     private final StringBuilder stringBuilder;
 
-    public StringStreamDumper(StringBuilder sb, TypeUsageInformation typeUsageInformation, Options options, IllegalIdentifierDump illegalIdentifierDump) {
-        this(sb, typeUsageInformation, options, illegalIdentifierDump, new MovableDumperContext());
+    public StringStreamDumper(MethodErrorCollector methodErrorCollector, StringBuilder sb, TypeUsageInformation typeUsageInformation, Options options, IllegalIdentifierDump illegalIdentifierDump) {
+        this(methodErrorCollector, sb, typeUsageInformation, options, illegalIdentifierDump, new MovableDumperContext());
     }
 
-    public StringStreamDumper(StringBuilder sb, TypeUsageInformation typeUsageInformation, Options options, IllegalIdentifierDump illegalIdentifierDump, MovableDumperContext context) {
+    public StringStreamDumper(MethodErrorCollector methodErrorCollector, StringBuilder sb, TypeUsageInformation typeUsageInformation, Options options, IllegalIdentifierDump illegalIdentifierDump, MovableDumperContext context) {
         super(typeUsageInformation, options, illegalIdentifierDump,context);
+        this.methodErrorCollector = methodErrorCollector;
         this.stringBuilder = sb;
     }
 
@@ -27,6 +29,7 @@ public class StringStreamDumper extends StreamDumper {
 
     @Override
     public void addSummaryError(Method method, String s) {
+        methodErrorCollector.addSummaryError(method, s);
     }
 
     @Override

--- a/src/org/benf/cfr/reader/util/output/TokenStreamDumper.java
+++ b/src/org/benf/cfr/reader/util/output/TokenStreamDumper.java
@@ -27,6 +27,7 @@ public class TokenStreamDumper extends AbstractDumper {
     private final OutputSinkFactory.Sink<SinkReturns.Token> sink;
     private final int version;
     private final JavaTypeInstance classType;
+    private final MethodErrorCollector methodErrorCollector;
     private final TypeUsageInformation typeUsageInformation;
     private final Options options;
     private final IllegalIdentifierDump illegalIdentifierDump;
@@ -41,11 +42,12 @@ public class TokenStreamDumper extends AbstractDumper {
 
     private final Set<JavaTypeInstance> emitted = SetFactory.newSet();
 
-    TokenStreamDumper(OutputSinkFactory.Sink<SinkReturns.Token> sink, int version, JavaTypeInstance classType, TypeUsageInformation typeUsageInformation, Options options, IllegalIdentifierDump illegalIdentifierDump, MovableDumperContext context) {
+    TokenStreamDumper(OutputSinkFactory.Sink<SinkReturns.Token> sink, int version, JavaTypeInstance classType, MethodErrorCollector methodErrorCollector, TypeUsageInformation typeUsageInformation, Options options, IllegalIdentifierDump illegalIdentifierDump, MovableDumperContext context) {
         super(context);
         this.sink = sink;
         this.version = version;
         this.classType = classType;
+        this.methodErrorCollector = methodErrorCollector;
         this.typeUsageInformation = typeUsageInformation;
         this.options = options;
         this.illegalIdentifierDump = illegalIdentifierDump;
@@ -331,7 +333,7 @@ public class TokenStreamDumper extends AbstractDumper {
 
     @Override
     public void addSummaryError(Method method, String s) {
-        // none currently.
+        methodErrorCollector.addSummaryError(method, s);
     }
 
     @Override
@@ -351,7 +353,7 @@ public class TokenStreamDumper extends AbstractDumper {
 
     @Override
     public Dumper withTypeUsageInformation(TypeUsageInformation innerclassTypeUsageInformation) {
-        return new TokenStreamDumper(sink, version, classType, innerclassTypeUsageInformation, options, illegalIdentifierDump, context);
+        return new TokenStreamDumper(sink, version, classType, methodErrorCollector, innerclassTypeUsageInformation, options, illegalIdentifierDump, context);
     }
 
     @Override


### PR DESCRIPTION
Previously sinks would not receive errors logged using `SummaryDumper.notifyError(JavaTypeInstance, Method, String)`, this is now fixed.

This pull request introduces a new interface `MethodErrorCollector`.
I think ideally `Dumper` should not have the `addSummaryError(Method method, String s)` method in the first place because some dumper implementations (e.g. `ToStringDumper`) are not designed to handle errors. However, passing an error collector to all the places where the method is currently called would require a possible rather large rewrite so I choose to solve it by using the new interface by some dumper implementations only.

Please let me know what you think.