### PR TITLE
Give more info about identifiers to Dumper

### DIFF
--- a/src/org/benf/cfr/reader/bytecode/analysis/parse/lvalue/AbstractFieldVariable.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/parse/lvalue/AbstractFieldVariable.java
@@ -114,6 +114,10 @@ public abstract class AbstractFieldVariable extends AbstractLValue {
         return classFileField;
     }
 
+    public Field getField() {
+        return classFileField == null ? null : classFileField.getField();
+    }
+
     @Override
     public SSAIdentifiers<LValue> collectVariableMutation(SSAIdentifierFactory<LValue, ?> ssaIdentifierFactory) {
         //noinspection unchecked

--- a/src/org/benf/cfr/reader/bytecode/analysis/parse/lvalue/FieldVariable.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/parse/lvalue/FieldVariable.java
@@ -115,7 +115,7 @@ public class FieldVariable extends AbstractFieldVariable {
                 object.dumpWithOuterPrecedence(d, getPrecedence(), Troolean.NEITHER).separator(".");
             }
         }
-        return d.fieldName(getFieldName(), getOwningClassType(), isHiddenDeclaration(), false, false);
+        return d.fieldName(getFieldName(), getField(), getOwningClassType(), isHiddenDeclaration(), false);
     }
 
     @Override

--- a/src/org/benf/cfr/reader/bytecode/analysis/parse/lvalue/StaticVariable.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/parse/lvalue/StaticVariable.java
@@ -63,9 +63,9 @@ public class StaticVariable extends AbstractFieldVariable {
     @Override
     public Dumper dumpInner(Dumper d) {
         if (knownSimple) {
-            return d.fieldName(getFieldName(), getOwningClassType(), false, true, false);
+            return d.fieldName(getFieldName(), getField(), getOwningClassType(), false, false);
         } else {
-            return d.dump(getOwningClassType(), TypeContext.Static).separator(".").fieldName(getFieldName(), getOwningClassType(), false, true, false);
+            return d.dump(getOwningClassType(), TypeContext.Static).separator(".").fieldName(getFieldName(), getField(), getOwningClassType(), false, false);
         }
     }
 

--- a/src/org/benf/cfr/reader/bytecode/analysis/parse/utils/scope/LocalClassScopeDiscoverImpl.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/parse/utils/scope/LocalClassScopeDiscoverImpl.java
@@ -12,6 +12,7 @@ import org.benf.cfr.reader.bytecode.analysis.structured.StructuredStatement;
 import org.benf.cfr.reader.bytecode.analysis.types.InnerClassInfo;
 import org.benf.cfr.reader.bytecode.analysis.types.JavaRefTypeInstance;
 import org.benf.cfr.reader.bytecode.analysis.types.JavaTypeInstance;
+import org.benf.cfr.reader.bytecode.analysis.types.MethodPrototype;
 import org.benf.cfr.reader.bytecode.analysis.variables.NamedVariable;
 import org.benf.cfr.reader.bytecode.analysis.variables.VariableFactory;
 import org.benf.cfr.reader.entities.Method;
@@ -69,6 +70,11 @@ public class LocalClassScopeDiscoverImpl extends AbstractLValueScopeDiscoverer {
 
         @Override
         public Dumper dump(Dumper d, boolean defines) {
+            return null;
+        }
+
+        @Override
+        public Dumper dumpParameter(Dumper d, MethodPrototype methodPrototype, int index, boolean defines) {
             return null;
         }
 

--- a/src/org/benf/cfr/reader/bytecode/analysis/structured/statement/StructuredCase.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/structured/statement/StructuredCase.java
@@ -76,7 +76,7 @@ public class StructuredCase extends AbstractStructuredBlockStatement {
                     // don't show the case part of that.
                     StaticVariable enumStatic = getEnumStatic(value);
                     if (enumStatic != null) {
-                        dumper.keyword("case ").fieldName(enumStatic.getFieldName(), enumStatic.getOwningClassType(), false, true, false).separator(": ");
+                        dumper.keyword("case ").fieldName(enumStatic.getFieldName(), enumStatic.getField(), enumStatic.getOwningClassType(), false, false).separator(": ");
                         if (x != last) dumper.newln();
                         continue;
                     }

--- a/src/org/benf/cfr/reader/bytecode/analysis/types/MethodPrototype.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/types/MethodPrototype.java
@@ -269,7 +269,7 @@ public class MethodPrototype implements TypeUsageCollectable {
                 annotationsHelper.dumpParamType(arg, paramIdx, d);
             }
             d.print(" ");
-            param.getName().dump(d, true);
+            param.getName().dumpParameter(d, this, paramIdx, true);
         }
         d.separator(")");
     }

--- a/src/org/benf/cfr/reader/bytecode/analysis/variables/NamedVariable.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/variables/NamedVariable.java
@@ -1,5 +1,6 @@
 package org.benf.cfr.reader.bytecode.analysis.variables;
 
+import org.benf.cfr.reader.bytecode.analysis.types.MethodPrototype;
 import org.benf.cfr.reader.util.output.Dumpable;
 import org.benf.cfr.reader.util.output.Dumper;
 
@@ -14,4 +15,6 @@ public interface NamedVariable extends Dumpable {
     Dumper dump(Dumper d);
 
     Dumper dump(Dumper d, boolean defines);
+
+    Dumper dumpParameter(Dumper d, MethodPrototype methodPrototype, int index, boolean defines);
 }

--- a/src/org/benf/cfr/reader/bytecode/analysis/variables/NamedVariableDefault.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/variables/NamedVariableDefault.java
@@ -1,5 +1,6 @@
 package org.benf.cfr.reader.bytecode.analysis.variables;
 
+import org.benf.cfr.reader.bytecode.analysis.types.MethodPrototype;
 import org.benf.cfr.reader.util.output.Dumper;
 
 public class NamedVariableDefault implements NamedVariable {
@@ -28,7 +29,12 @@ public class NamedVariableDefault implements NamedVariable {
 
     @Override
     public Dumper dump(Dumper d, boolean defines) {
-        return d.identifier(name, this, defines);
+        return d.variableName(name, this, defines);
+    }
+
+    @Override
+    public Dumper dumpParameter(Dumper d, MethodPrototype methodPrototype, int index, boolean defines) {
+        return d.parameterName(name, methodPrototype, index, defines);
     }
 
     @Override

--- a/src/org/benf/cfr/reader/bytecode/analysis/variables/NamedVariableFromHint.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/variables/NamedVariableFromHint.java
@@ -1,5 +1,6 @@
 package org.benf.cfr.reader.bytecode.analysis.variables;
 
+import org.benf.cfr.reader.bytecode.analysis.types.MethodPrototype;
 import org.benf.cfr.reader.util.output.Dumper;
 
 public class NamedVariableFromHint implements NamedVariable {
@@ -30,7 +31,12 @@ public class NamedVariableFromHint implements NamedVariable {
 
     @Override
     public Dumper dump(Dumper d, boolean defines) {
-        return d.identifier(name, this, defines);
+        return d.variableName(name, this, defines);
+    }
+
+    @Override
+    public Dumper dumpParameter(Dumper d, MethodPrototype methodPrototype, int index, boolean defines) {
+        return d.parameterName(name, methodPrototype, index, defines);
     }
 
     @Override

--- a/src/org/benf/cfr/reader/entities/ClassFile.java
+++ b/src/org/benf/cfr/reader/entities/ClassFile.java
@@ -1192,7 +1192,7 @@ public class ClassFile implements Dumpable, TypeUsageCollectable {
     }
 
     public void dumpClassIdentity(Dumper d) {
-        d.dump(getThisClassConstpoolEntry().getTypeInstance());
+        d.dump(getThisClassConstpoolEntry().getTypeInstance(), true);
         TypeAnnotationHelper typeAnnotations = TypeAnnotationHelper.create(attributes,
                 TypeAnnotationEntryValue.type_generic_class_interface,
                 TypeAnnotationEntryValue.type_type_parameter_class_interface);

--- a/src/org/benf/cfr/reader/entities/Field.java
+++ b/src/org/benf/cfr/reader/entities/Field.java
@@ -188,7 +188,7 @@ public class Field implements KnowsRawSize, TypeUsageCollectable {
             d.dump(comments);
             d.dump(jah);
         }
-        d.print(' ').fieldName(name, owner.getClassType(), false, false, true);
+        d.print(' ').fieldName(name, this, owner.getClassType(), false, true);
     }
 
     public boolean isAccessibleFrom(JavaRefTypeInstance maybeCaller, ClassFile classFile) {

--- a/src/org/benf/cfr/reader/entities/classfilehelpers/ClassFileDumperEnum.java
+++ b/src/org/benf/cfr/reader/entities/classfilehelpers/ClassFileDumperEnum.java
@@ -51,7 +51,7 @@ public class ClassFileDumperEnum extends AbstractClassFileDumper {
     private static void dumpEntry(Dumper d, Pair<StaticVariable, AbstractConstructorInvokation> entry, boolean last, JavaTypeInstance classType) {
         StaticVariable staticVariable = entry.getFirst();
         AbstractConstructorInvokation constructorInvokation = entry.getSecond();
-        d.fieldName(staticVariable.getFieldName(), classType, false, true, true);
+        d.fieldName(staticVariable.getFieldName(), staticVariable.getField(), classType, false, true);
 
         if (constructorInvokation instanceof ConstructorInvokationSimple) {
             List<Expression> args = constructorInvokation.getArgs();

--- a/src/org/benf/cfr/reader/state/TypeUsageCollectingDumper.java
+++ b/src/org/benf/cfr/reader/state/TypeUsageCollectingDumper.java
@@ -4,7 +4,9 @@ import org.benf.cfr.reader.bytecode.analysis.types.JavaRefTypeInstance;
 import org.benf.cfr.reader.bytecode.analysis.types.JavaTypeInstance;
 import org.benf.cfr.reader.bytecode.analysis.types.MethodPrototype;
 import org.benf.cfr.reader.bytecode.analysis.types.TypeConstants;
+import org.benf.cfr.reader.bytecode.analysis.variables.NamedVariable;
 import org.benf.cfr.reader.entities.ClassFile;
+import org.benf.cfr.reader.entities.Field;
 import org.benf.cfr.reader.entities.Method;
 import org.benf.cfr.reader.mapping.NullMapping;
 import org.benf.cfr.reader.mapping.ObfuscationMapping;
@@ -89,12 +91,27 @@ public class TypeUsageCollectingDumper implements Dumper {
     }
 
     @Override
-    public Dumper methodName(String s, MethodPrototype p, boolean special, boolean defines) {
+    public Dumper packageName(JavaRefTypeInstance t) {
         return this;
     }
 
     @Override
-    public Dumper packageName(JavaRefTypeInstance t) {
+    public Dumper fieldName(String name, Field field, JavaTypeInstance owner, boolean hiddenDeclaration, boolean defines) {
+        return this;
+    }
+
+    @Override
+    public Dumper methodName(String name, MethodPrototype method, boolean special, boolean defines) {
+        return this;
+    }
+
+    @Override
+    public Dumper parameterName(String name, MethodPrototype method, int index, boolean defines) {
+        return this;
+    }
+
+    @Override
+    public Dumper variableName(String name, NamedVariable variable, boolean defines) {
         return this;
     }
 
@@ -139,11 +156,6 @@ public class TypeUsageCollectingDumper implements Dumper {
     }
 
     @Override
-    public Dumper fieldName(String name, JavaTypeInstance owner, boolean hiddenDeclaration, boolean isStatic, boolean defines) {
-        return this;
-    }
-
-    @Override
     public Dumper withTypeUsageInformation(TypeUsageInformation innerclassTypeUsageInformation) {
         return this;
     }
@@ -171,6 +183,11 @@ public class TypeUsageCollectingDumper implements Dumper {
     @Override
     public Dumper dump(JavaTypeInstance javaTypeInstance) {
         return dump(javaTypeInstance, TypeContext.None);
+    }
+
+    @Override
+    public Dumper dump(JavaTypeInstance javaTypeInstance, boolean defines) {
+        return dump(javaTypeInstance);
     }
 
     @Override

--- a/src/org/benf/cfr/reader/util/output/AbstractDumper.java
+++ b/src/org/benf/cfr/reader/util/output/AbstractDumper.java
@@ -63,6 +63,11 @@ abstract class AbstractDumper implements Dumper {
     }
 
     @Override
+    public Dumper dump(JavaTypeInstance javaTypeInstance, boolean defines) {
+        return dump(javaTypeInstance);
+    }
+
+    @Override
     public Dumper removePendingCarriageReturn() {
         context.pendingCR = false;
         context.atStart = false;

--- a/src/org/benf/cfr/reader/util/output/DelegatingDumper.java
+++ b/src/org/benf/cfr/reader/util/output/DelegatingDumper.java
@@ -3,6 +3,8 @@ package org.benf.cfr.reader.util.output;
 import org.benf.cfr.reader.bytecode.analysis.types.JavaRefTypeInstance;
 import org.benf.cfr.reader.bytecode.analysis.types.JavaTypeInstance;
 import org.benf.cfr.reader.bytecode.analysis.types.MethodPrototype;
+import org.benf.cfr.reader.bytecode.analysis.variables.NamedVariable;
+import org.benf.cfr.reader.entities.Field;
 import org.benf.cfr.reader.entities.Method;
 import org.benf.cfr.reader.mapping.ObfuscationMapping;
 import org.benf.cfr.reader.state.TypeUsageInformation;
@@ -72,14 +74,32 @@ public abstract class DelegatingDumper implements Dumper {
     }
 
     @Override
-    public Dumper methodName(String s, MethodPrototype p, boolean special, boolean defines) {
-        delegate.methodName(s, p, special, defines);
+    public Dumper packageName(JavaRefTypeInstance t) {
+        delegate.packageName(t);
         return this;
     }
 
     @Override
-    public Dumper packageName(JavaRefTypeInstance t) {
-        delegate.packageName(t);
+    public Dumper fieldName(String name, Field field, JavaTypeInstance owner, boolean hiddenDeclaration, boolean defines) {
+        delegate.fieldName(name, field, owner, hiddenDeclaration, defines);
+        return this;
+    }
+
+    @Override
+    public Dumper methodName(String name, MethodPrototype method, boolean special, boolean defines) {
+        delegate.methodName(name, method, special, defines);
+        return this;
+    }
+
+    @Override
+    public Dumper parameterName(String name, MethodPrototype method, int index, boolean defines) {
+        delegate.parameterName(name, method, index, defines);
+        return this;
+    }
+
+    @Override
+    public Dumper variableName(String name, NamedVariable variable, boolean defines) {
+        delegate.variableName(name, variable, defines);
         return this;
     }
 
@@ -127,6 +147,12 @@ public abstract class DelegatingDumper implements Dumper {
     }
 
     @Override
+    public Dumper dump(JavaTypeInstance javaTypeInstance, boolean defines) {
+        delegate.dump(javaTypeInstance, defines);
+        return this;
+    }
+
+    @Override
     public Dumper dump(JavaTypeInstance javaTypeInstance, TypeContext typeContext) {
         delegate.dump(javaTypeInstance, typeContext);
         return this;
@@ -145,12 +171,6 @@ public abstract class DelegatingDumper implements Dumper {
     @Override
     public boolean canEmitClass(JavaTypeInstance type) {
         return delegate.canEmitClass(type);
-    }
-
-    @Override
-    public Dumper fieldName(String name, JavaTypeInstance owner, boolean hiddenDeclaration, boolean isStatic, boolean defines) {
-        delegate.fieldName(name, owner, hiddenDeclaration, isStatic, defines);
-        return this;
     }
 
     @Override

--- a/src/org/benf/cfr/reader/util/output/Dumper.java
+++ b/src/org/benf/cfr/reader/util/output/Dumper.java
@@ -3,6 +3,8 @@ package org.benf.cfr.reader.util.output;
 import org.benf.cfr.reader.bytecode.analysis.types.JavaRefTypeInstance;
 import org.benf.cfr.reader.bytecode.analysis.types.JavaTypeInstance;
 import org.benf.cfr.reader.bytecode.analysis.types.MethodPrototype;
+import org.benf.cfr.reader.bytecode.analysis.variables.NamedVariable;
+import org.benf.cfr.reader.entities.Field;
 import org.benf.cfr.reader.entities.Method;
 import org.benf.cfr.reader.mapping.ObfuscationMapping;
 import org.benf.cfr.reader.state.TypeUsageInformation;
@@ -35,11 +37,17 @@ public interface Dumper extends MethodErrorCollector {
 
     Dumper print(String s);
 
-    Dumper methodName(String s, MethodPrototype p, boolean special, boolean defines);
-
     Dumper packageName(JavaRefTypeInstance t);
 
-    Dumper identifier(String s, Object ref, boolean defines);
+    Dumper fieldName(String name, Field field, JavaTypeInstance owner, boolean hiddenDeclaration, boolean defines);
+
+    Dumper methodName(String name, MethodPrototype method, boolean special, boolean defines);
+
+    Dumper parameterName(String name, MethodPrototype method, int index, boolean defines);
+
+    Dumper variableName(String name, NamedVariable variable, boolean defines);
+
+    Dumper identifier(String name, Object ref, boolean defines);
 
     Dumper print(char c);
 
@@ -55,8 +63,6 @@ public interface Dumper extends MethodErrorCollector {
     void addSummaryError(Method method, String s);
 
     boolean canEmitClass(JavaTypeInstance type);
-
-    Dumper fieldName(String name, JavaTypeInstance owner, boolean hiddenDeclaration, boolean isStatic, boolean defines);
 
     Dumper withTypeUsageInformation(TypeUsageInformation innerclassTypeUsageInformation);
 
@@ -89,6 +95,7 @@ public interface Dumper extends MethodErrorCollector {
 
     Dumper dump(JavaTypeInstance javaTypeInstance);
 
-    Dumper dump(Dumpable d);
+    Dumper dump(JavaTypeInstance javaTypeInstance, boolean defines);
 
+    Dumper dump(Dumpable d);
 }

--- a/src/org/benf/cfr/reader/util/output/StreamDumper.java
+++ b/src/org/benf/cfr/reader/util/output/StreamDumper.java
@@ -4,6 +4,8 @@ import org.benf.cfr.reader.bytecode.analysis.parse.utils.QuotingUtils;
 import org.benf.cfr.reader.bytecode.analysis.types.JavaRefTypeInstance;
 import org.benf.cfr.reader.bytecode.analysis.types.JavaTypeInstance;
 import org.benf.cfr.reader.bytecode.analysis.types.MethodPrototype;
+import org.benf.cfr.reader.bytecode.analysis.variables.NamedVariable;
+import org.benf.cfr.reader.entities.Field;
 import org.benf.cfr.reader.mapping.NullMapping;
 import org.benf.cfr.reader.mapping.ObfuscationMapping;
 import org.benf.cfr.reader.state.TypeUsageInformation;
@@ -64,22 +66,41 @@ public abstract class StreamDumper extends AbstractDumper {
     }
 
     @Override
-    public Dumper identifier(String s, Object ref, boolean defines) {
-        return print(illegalIdentifierDump.getLegalIdentifierFor(s));
-    }
-
-    @Override
-    public Dumper methodName(String s, MethodPrototype p, boolean special, boolean defines) {
-        return identifier(s, null, defines);
-    }
-
-    @Override
     public Dumper packageName(JavaRefTypeInstance t) {
         String s = t.getPackageName();
         if (!s.isEmpty()) {
             keyword("package ").print(s).endCodeln().newln();
         }
         return this;
+    }
+
+    @Override
+    public Dumper fieldName(String name, Field field, JavaTypeInstance owner, boolean hiddenDeclaration, boolean defines) {
+        identifier(name, null, defines);
+        return this;
+    }
+
+    @Override
+    public Dumper methodName(String name, MethodPrototype method, boolean special, boolean defines) {
+        identifier(name, null, defines);
+        return this;
+    }
+
+    @Override
+    public Dumper parameterName(String name, MethodPrototype method, int index, boolean defines) {
+        identifier(name, null, defines);
+        return this;
+    }
+
+    @Override
+    public Dumper variableName(String name, NamedVariable variable, boolean defines) {
+        identifier(name, null, defines);
+        return this;
+    }
+
+    @Override
+    public Dumper identifier(String s, Object ref, boolean defines) {
+        return print(illegalIdentifierDump.getLegalIdentifierFor(s));
     }
 
     @Override
@@ -172,12 +193,6 @@ public abstract class StreamDumper extends AbstractDumper {
     @Override
     public void indent(int diff) {
         context.indent += diff;
-    }
-
-    @Override
-    public Dumper fieldName(String name, JavaTypeInstance owner, boolean hiddenDeclaration, boolean isStatic, boolean defines) {
-        identifier(name, null, defines);
-        return this;
     }
 
     @Override

--- a/src/org/benf/cfr/reader/util/output/ToStringDumper.java
+++ b/src/org/benf/cfr/reader/util/output/ToStringDumper.java
@@ -3,6 +3,8 @@ package org.benf.cfr.reader.util.output;
 import org.benf.cfr.reader.bytecode.analysis.types.JavaRefTypeInstance;
 import org.benf.cfr.reader.bytecode.analysis.types.JavaTypeInstance;
 import org.benf.cfr.reader.bytecode.analysis.types.MethodPrototype;
+import org.benf.cfr.reader.bytecode.analysis.variables.NamedVariable;
+import org.benf.cfr.reader.entities.Field;
 import org.benf.cfr.reader.entities.Method;
 import org.benf.cfr.reader.mapping.NullMapping;
 import org.benf.cfr.reader.mapping.ObfuscationMapping;
@@ -42,22 +44,37 @@ public class ToStringDumper extends AbstractDumper {
     }
 
     @Override
-    public Dumper identifier(String s, Object ref, boolean defines) {
-        return print(s);
-    }
-
-    @Override
-    public Dumper methodName(String s, MethodPrototype p, boolean special, boolean defines) {
-        return identifier(s, null, defines);
-    }
-
-    @Override
     public Dumper packageName(JavaRefTypeInstance t) {
         String s = t.getPackageName();
         if (!s.isEmpty()) {
             keyword("package ").print(s).endCodeln().newln();
         }
         return this;
+    }
+
+    @Override
+    public Dumper fieldName(String name, Field field, JavaTypeInstance owner, boolean hiddenDeclaration, boolean defines) {
+        return identifier(name, null, defines);
+    }
+
+    @Override
+    public Dumper methodName(String name, MethodPrototype method, boolean special, boolean defines) {
+        return identifier(name, null, defines);
+    }
+
+    @Override
+    public Dumper parameterName(String name, MethodPrototype method, int index, boolean defines) {
+        return identifier(name, null, defines);
+    }
+
+    @Override
+    public Dumper variableName(String name, NamedVariable variable, boolean defines) {
+        return identifier(name, null, defines);
+    }
+
+    @Override
+    public Dumper identifier(String s, Object ref, boolean defines) {
+        return print(s);
     }
 
     @Override
@@ -151,12 +168,6 @@ public class ToStringDumper extends AbstractDumper {
     @Override
     public Dumper dump(JavaTypeInstance javaTypeInstance, TypeContext typeContext) {
         javaTypeInstance.dumpInto(this, typeUsageInformation, typeContext);
-        return this;
-    }
-
-    @Override
-    public Dumper fieldName(String name, JavaTypeInstance owner, boolean hiddenDeclaration, boolean isStatic, boolean defines) {
-        identifier(name, null, defines);
         return this;
     }
 

--- a/src/org/benf/cfr/reader/util/output/TokenStreamDumper.java
+++ b/src/org/benf/cfr/reader/util/output/TokenStreamDumper.java
@@ -5,6 +5,8 @@ import org.benf.cfr.reader.api.SinkReturns;
 import org.benf.cfr.reader.bytecode.analysis.types.JavaRefTypeInstance;
 import org.benf.cfr.reader.bytecode.analysis.types.JavaTypeInstance;
 import org.benf.cfr.reader.bytecode.analysis.types.MethodPrototype;
+import org.benf.cfr.reader.bytecode.analysis.variables.NamedVariable;
+import org.benf.cfr.reader.entities.Field;
 import org.benf.cfr.reader.entities.Method;
 import org.benf.cfr.reader.mapping.NullMapping;
 import org.benf.cfr.reader.mapping.ObfuscationMapping;
@@ -253,22 +255,42 @@ public class TokenStreamDumper extends AbstractDumper {
     }
 
     @Override
-    public Dumper methodName(String s, MethodPrototype p, boolean special, boolean defines) {
-        if (defines) {
-            sink(new Token(METHOD, s, refMap.get(p), SinkReturns.TokenTypeFlags.DEFINES));
-        } else {
-            sink(new Token(METHOD, s, refMap.get(p)));
-        }
-        return this;
-    }
-
-    @Override
     public Dumper packageName(JavaRefTypeInstance t) {
         String s = t.getPackageName();
         if (!s.isEmpty()) {
             keyword("package ").print(s).endCodeln().newln();
         }
         return this;
+    }
+
+    @Override
+    public Dumper fieldName(String name, Field field, JavaTypeInstance owner, boolean hiddenDeclaration, boolean defines) {
+        if (defines) {
+            sink(new Token(FIELD, name, SinkReturns.TokenTypeFlags.DEFINES));
+        } else {
+            sink(FIELD, name);
+        }
+        return this;
+    }
+
+    @Override
+    public Dumper methodName(String s, MethodPrototype method, boolean special, boolean defines) {
+        if (defines) {
+            sink(new Token(METHOD, s, refMap.get(method), SinkReturns.TokenTypeFlags.DEFINES));
+        } else {
+            sink(new Token(METHOD, s, refMap.get(method)));
+        }
+        return this;
+    }
+
+    @Override
+    public Dumper parameterName(String name, MethodPrototype method, int index, boolean defines) {
+        return identifier(name, null, defines);
+    }
+
+    @Override
+    public Dumper variableName(String name, NamedVariable variable, boolean defines) {
+        return identifier(name, null, defines);
     }
 
     @Override
@@ -339,16 +361,6 @@ public class TokenStreamDumper extends AbstractDumper {
     @Override
     public boolean canEmitClass(JavaTypeInstance type) {
         return emitted.add(type);
-    }
-
-    @Override
-    public Dumper fieldName(String name, JavaTypeInstance owner, boolean hiddenDeclaration, boolean isStatic, boolean defines) {
-        if (defines) {
-            sink(new Token(FIELD, name, SinkReturns.TokenTypeFlags.DEFINES));
-        } else {
-            sink(FIELD, name);
-        }
-        return this;
     }
 
     @Override


### PR DESCRIPTION
We'd like to use CFR as an alternative to Procyon in [Enigma](https://github.com/FabricMC/Enigma), a tool for remapping obfuscated Java code. See [this PR](https://github.com/FabricMC/Enigma/pull/192). To do this, we need to build a mapping between code regions and the entries they refer to. This PR extends the `Dumper` class to add:
 - `parameterName(String name, MethodPrototype method, int index, boolean defines)`
 - A `defines` parameter to the `dump(JavaTypeInstance javaTypeInstance)` method, which is set to true when the type instance is the class name in a class definition
 - A `field` parameter to the `fieldName` method, since we need the field type too (obfuscation can rename several fields to the same name, so just the name and owner isn't enough).