### PR TITLE
Fix identifiers containing ignorable chars not being renamed

### DIFF
--- a/src/org/benf/cfr/reader/util/output/IllegalIdentifierReplacement.java
+++ b/src/org/benf/cfr/reader/util/output/IllegalIdentifierReplacement.java
@@ -42,7 +42,10 @@ public class IllegalIdentifierReplacement implements IllegalIdentifierDump {
             return true;
         }
         for (int x=1;x<chars.length;++x) {
-            if (!Character.isJavaIdentifierPart(chars[x])) return true;
+            char c = chars[x];
+            // If identifier contains ignorable char, it cannot be represented in source
+            // because e.g. `a\u0008` is effectively `a` when re-compiled
+            if (!Character.isJavaIdentifierPart(c) || Character.isIdentifierIgnorable(c)) return true;
         }
         return false;
     }


### PR DESCRIPTION
Ignorable chars (Character.isIdentifierIgnorable) are ignored as part of identifiers (cannot be leading, but can be in between and trailing) when compiling. They can therefore normally not appear in a class file unless it was modified. Since they cannot be represented in source (and could easily cause identifier collisions), identifiers containing them are now considered invalid.

This was only added to the JLS for Java 10 (see [JDK-6214519](https://bugs.openjdk.java.net/browse/JDK-6214519)), however the behavior also exists in earlier versions.

Demonstration of the issue:
1. Download [IdentifierIgnorable.class.txt](https://github.com/leibnitz27/cfr/files/4566729/IdentifierIgnorable.class.txt) (remove `.txt`, that is only to make GitHub happy)
2. Decompile with `--rename true`
