### PR TITLE
Provide more build information to CFR, don't use getImplementationVersion()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <profile>
             <id>jdk9plus</id>
             <activation>
-                <jdk>[1.9,)</jdk>
+                <jdk>[9,)</jdk>
             </activation>
             <build>
                 <plugins>
@@ -55,6 +55,42 @@
     <build>
         <sourceDirectory>src</sourceDirectory>
         <plugins>
+            <!-- For getting Git revision information -->
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <version>4.0.0</version>
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                        <configuration>
+                            <!-- Only use local Git repository information -->
+                            <offline>true</offline>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- For inserting build information into Java class -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>templating-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <executions>
+                    <execution>
+                        <id>filter-src</id>
+                        <goals>
+                            <goal>filter-sources</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirectory>${project.basedir}/src-templates</sourceDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -73,6 +109,7 @@
                     <archive>
                         <manifest>
                             <mainClass>org.benf.cfr.reader.Main</mainClass>
+                            <!-- Not used by CFR, but maybe useful for other projects depending on CFR -->
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                             <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                         </manifest>

--- a/src-templates/org/benf/cfr/reader/util/CfrVersionInfo.java
+++ b/src-templates/org/benf/cfr/reader/util/CfrVersionInfo.java
@@ -1,0 +1,30 @@
+package org.benf.cfr.reader.util;
+
+/**
+ * Provides information about the CFR build.
+ *
+ * <p>The information in this class is automatically generated when the project
+ * is built.
+ */
+public class CfrVersionInfo {
+    private CfrVersionInfo() {}
+
+    /** CFR version */
+    public static final String VERSION = "${project.version}";
+    /**
+     * Abbreviated Git commit hash of the commit representing this state
+     * of the project.
+     */
+    public static final String GIT_COMMIT_ABBREVIATED = "${git.commit.id.abbrev}";
+    /**
+     * Whether the working tree contained not yet committed changes when
+     * the project was built.
+     *
+     * <p>This information can be useful for error reports to find out
+     * if changes have been made.
+     */
+    public static final boolean GIT_IS_DIRTY = "${git.dirty}".equals("true");
+
+    /** String consisting of CFR version and Git commit hash */
+    public static final String VERSION_INFO = VERSION + " (" + GIT_COMMIT_ABBREVIATED + (GIT_IS_DIRTY ? "-dirty" : "") + ")";
+}

--- a/src/org/benf/cfr/reader/Driver.java
+++ b/src/org/benf/cfr/reader/Driver.java
@@ -12,6 +12,7 @@ import org.benf.cfr.reader.state.TypeUsageCollectingDumper;
 import org.benf.cfr.reader.state.TypeUsageInformation;
 import org.benf.cfr.reader.util.AnalysisType;
 import org.benf.cfr.reader.util.CannotLoadClassException;
+import org.benf.cfr.reader.util.CfrVersionInfo;
 import org.benf.cfr.reader.util.MiscConstants;
 import org.benf.cfr.reader.util.MiscUtils;
 import org.benf.cfr.reader.util.collections.Functional;
@@ -117,7 +118,7 @@ class Driver {
             ProgressDumper progressDumper = dumperFactory.getProgressDumper();
             summaryDumper = dumperFactory.getSummaryDumper();
             summaryDumper.notify("Summary for " + path);
-            summaryDumper.notify(MiscConstants.CFR_HEADER_BRA + " " + MiscConstants.CFR_VERSION);
+            summaryDumper.notify(MiscConstants.CFR_HEADER_BRA + " " + CfrVersionInfo.VERSION_INFO);
             progressDumper.analysingPath(path);
             Map<Integer, List<JavaTypeInstance>> clstypes = dcCommonState.explicitlyLoadJar(path, analysisType);
             Set<JavaTypeInstance> versionCollisions = getVersionCollisions(clstypes);

--- a/src/org/benf/cfr/reader/entities/classfilehelpers/AbstractClassFileDumper.java
+++ b/src/org/benf/cfr/reader/entities/classfilehelpers/AbstractClassFileDumper.java
@@ -13,6 +13,7 @@ import org.benf.cfr.reader.state.DCCommonState;
 import org.benf.cfr.reader.state.DetectedStaticImport;
 import org.benf.cfr.reader.state.TypeUsageInformation;
 import org.benf.cfr.reader.util.CannotLoadClassException;
+import org.benf.cfr.reader.util.CfrVersionInfo;
 import org.benf.cfr.reader.util.DecompilerComments;
 import org.benf.cfr.reader.util.MiscConstants;
 import org.benf.cfr.reader.util.collections.Functional;
@@ -51,8 +52,12 @@ abstract class AbstractClassFileDumper implements ClassFileDumper {
     void dumpTopHeader(ClassFile classFile, Dumper d, boolean showPackage) {
         if (dcCommonState == null) return;
         Options options = dcCommonState.getOptions();
-        String header = MiscConstants.CFR_HEADER_BRA +
-                (options.getOption(OptionsImpl.SHOW_CFR_VERSION) ? (" " + MiscConstants.CFR_VERSION) : "") + ".";
+        String header = MiscConstants.CFR_HEADER_BRA;
+        if (options.getOption(OptionsImpl.SHOW_CFR_VERSION)) {
+            header += " " + CfrVersionInfo.VERSION_INFO;
+        }
+        header += '.';
+
         d.beginBlockComment(false);
         d.print(header).newln();
         if (options.getOption(OptionsImpl.DECOMPILER_COMMENTS)) {

--- a/src/org/benf/cfr/reader/util/MiscConstants.java
+++ b/src/org/benf/cfr/reader/util/MiscConstants.java
@@ -3,25 +3,6 @@ package org.benf.cfr.reader.util;
 import java.util.regex.Pattern;
 
 public interface MiscConstants {
-    class Version {
-        private static String version;
-
-        static String getVersion() {
-            if (version != null) return version;
-            try {
-                version = Version.class.getPackage().getImplementationVersion();
-            } catch (Exception ignore) {
-                //
-            }
-            if (version == null) {
-                version = "<Could not determine version>";
-            }
-            return version;
-        }
-    }
-
-    String CFR_VERSION = Version.getVersion();
-
     String CFR_HEADER_BRA = "Decompiled with CFR";
 
     String INIT_METHOD = "<init>";

--- a/src/org/benf/cfr/reader/util/getopt/GetOptParser.java
+++ b/src/org/benf/cfr/reader/util/getopt/GetOptParser.java
@@ -3,6 +3,7 @@ package org.benf.cfr.reader.util.getopt;
 import org.benf.cfr.reader.bytecode.analysis.parse.utils.Pair;
 import org.benf.cfr.reader.util.collections.ListFactory;
 import org.benf.cfr.reader.util.collections.MapFactory;
+import org.benf.cfr.reader.util.CfrVersionInfo;
 import org.benf.cfr.reader.util.MiscConstants;
 
 import java.util.*;
@@ -100,7 +101,7 @@ public class GetOptParser {
     }
 
     private static void printErrHeader() {
-        System.err.println("CFR " + MiscConstants.CFR_VERSION + "\n");
+        System.err.println("CFR " + CfrVersionInfo.VERSION_INFO + "\n");
     }
 
     private static void printUsage() {


### PR DESCRIPTION
The version information now includes the commit hash and whether the working tree was dirty when the project was built.
It doesn't use `Package.getImplementationVersion()` anymore and should therefore continue to work even if CFR is packaged in a fat / uber jar.

To accomplish this, it uses
- https://github.com/git-commit-id/git-commit-id-maven-plugin
To get the Git commit hash and to determine whether the working tree is dirty
- https://www.mojohaus.org/templating-maven-plugin/
To populate the `CfrVersionInfo.java` with the project version and Git information

The result when running `java -jar cfr-0.150-SNAPSHOT.jar` is (for example):
```
CFR 0.150-SNAPSHOT (64ce6e4)
```
Respectively if the working tree is dirty:
```
CFR 0.150-SNAPSHOT (64ce6e4-dirty)
```