### PR TITLE
Delete src/META-INF/MANIFEST.MF

### DIFF
--- a/src/META-INF/MANIFEST.MF
+++ b/src/META-INF/MANIFEST.MF
@@ -1,3 +1,0 @@
-Manifest-Version: 1.0
-Main-Class: org.benf.cfr.reader.Main
-


### PR DESCRIPTION
`MANIFEST.MF` is already created by the maven-jar-plugin when the project is built and contains all the information present in the `src/META-INF/MANIFEST.MF` file.