### PR TITLE
Attempt to remove try blocks without throwing/printable code

### DIFF
--- a/src/org/benf/cfr/reader/bytecode/analysis/opgraph/op3rewriters/ExceptionRewriters.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/opgraph/op3rewriters/ExceptionRewriters.java
@@ -348,15 +348,14 @@ public class ExceptionRewriters {
             boolean printable = false;
 
             Op03SimpleStatement last = tryStatement.getTargets().get(tryStatement.getTargets().size() - 1);
-            Iterator<Op03SimpleStatement> targets = tryStatement.getTargets().iterator();
-            Op03SimpleStatement target;
-            while (targets.hasNext()) {
-                target = targets.next();
-                if (target == last) break; // dont check the terminating catch statement
+            for (Op03SimpleStatement target : tryStatement.getTargets()) {
                 Statement statement = target.getStatement();
 
+                // dont check the terminating catch statement
+                if (target == last && statement instanceof CatchStatement) break;
+
                 if (!(
-                    statement instanceof GotoStatement
+                    (statement instanceof GotoStatement && !(statement instanceof IfStatement))
                     ||
                     statement instanceof Nop
                 )) {


### PR DESCRIPTION
Currently bytecode like the following:
```
A:
GOTO C
B:
// do something with the exception
C:
Try A->B Handled by B
```
Will result in an output like the following:
```Java
try {
} catch (Throwable t) {
	// do something with the exception
}
```

This is especially obvious in radon obfuscated applications where random try catches are added to single instructions like `goto`.

For now I have created a check where if try blocks contain no printable statements, and no statements that can throw an exception, the try block is removed.

This could be taken a step further, and all try blocks that are unable to throw an exception could be removed, however this would result in inaccurate output on valid javac classes. Let me know if you want this implemented and I can modify the PR.

Example output before:
```Java
public class hhgg {
    private static /* bridge */ /* synthetic */ void ggghhg() {
        boolean bl;
        try {
        }
        catch (hghghhhg hghghhhg2) {
            hghghhhg2.ghgggghh();
            throw hghghhhg2;
        }
        try {
        }
        catch (hghghhhg hghghhhg3) {
            hghghhhg3.ghgggghh();
            throw hghghhhg3;
        }
        try {
        }
        catch (hghghhhg hghghhhg4) {
            hghghhhg4.ghgggghh();
            throw hghghhhg4;
        }
        try {
        }
        catch (hghghhhg hghghhhg5) {
            hghghhhg5.ghgggghh();
            throw hghghhhg5;
        }
        try {
        }
        catch (hghghhhg hghghhhg6) {
            hghghhhg6.ghgggghh();
            throw hghghhhg6;
        }
        try {
            bl = ggghghg;
        }
        catch (hghghhhg hghghhhg7) {
            hghghhhg7.ghgggghh();
            throw hghghhhg7;
        }
        if (!bl) {
            String string;
            String[] stringArray;
            String[] stringArray2;
            int n;
            try {
                n = 3;
            }
            catch (hghghhhg hghghhhg8) {
                hghghhhg8.ghgggghh();
                throw hghghhhg8;
            }
            try {
                stringArray2 = new String[n];
            }
            catch (hghghhhg hghghhhg9) {
                hghghhhg9.ghgggghh();
                throw hghghhhg9;
            }
            try {
                stringArray2[0] = "65537";
            }
            catch (hghghhhg hghghhhg10) {
                hghghhhg10.ghgggghh();
                throw hghghhhg10;
            }
            try {
                stringArray = stringArray2;
                stringArray2[1] = "RSA";
            }
            catch (hghghhhg hghghhhg11) {
                hghghhhg11.ghgggghh();
                throw hghghhhg11;
            }
            try {
                string = "RSA";
            }
            catch (hghghhhg hghghhhg12) {
                hghghhhg12.ghgggghh();
                throw hghghhhg12;
            }
            try {
                stringArray[2] = string;
            }
            catch (hghghhhg hghghhhg13) {
                hghghhhg13.ghgggghh();
                throw hghghhhg13;
            }
            try {
                ghhhhh = stringArray;
                if (!bl) {
                    return;
                }
            }
            catch (hghghhhg hghghhhg14) {
                hghghhhg14.ghgggghh();
                throw hghghhhg14;
            }
        }
    }
}
```

Example output after:
```Java
public class hhgg {
    private static /* bridge */ /* synthetic */ void ggghhg() {
        boolean bl;
        try {
            bl = ggghghg;
        }
        catch (hghghhhg hghghhhg2) {
            hghghhhg2.ghgggghh();
            throw hghghhhg2;
        }
        if (!bl) {
            String string;
            String[] stringArray;
            String[] stringArray2;
            int n;
            try {
                n = 3;
            }
            catch (hghghhhg hghghhhg3) {
                hghghhhg3.ghgggghh();
                throw hghghhhg3;
            }
            try {
                stringArray2 = new String[n];
            }
            catch (hghghhhg hghghhhg4) {
                hghghhhg4.ghgggghh();
                throw hghghhhg4;
            }
            try {
                stringArray2[0] = "65537";
            }
            catch (hghghhhg hghghhhg5) {
                hghghhhg5.ghgggghh();
                throw hghghhhg5;
            }
            try {
                stringArray = stringArray2;
                stringArray2[1] = "RSA";
            }
            catch (hghghhhg hghghhhg6) {
                hghghhhg6.ghgggghh();
                throw hghghhhg6;
            }
            try {
                string = "RSA";
            }
            catch (hghghhhg hghghhhg7) {
                hghghhhg7.ghgggghh();
                throw hghghhhg7;
            }
            try {
                stringArray[2] = string;
            }
            catch (hghghhhg hghghhhg8) {
                hghghhhg8.ghgggghh();
                throw hghghhhg8;
            }
            try {
                ghhhhh = stringArray;
                if (!bl) {
                    return;
                }
            }
            catch (hghghhhg hghghhhg9) {
                hghghhhg9.ghgggghh();
                throw hghghhhg9;
            }
        }
    }
}
```