### PR TITLE
Better exception formatting dumping

### DIFF
--- a/src/org/benf/cfr/reader/bytecode/analysis/opgraph/op3rewriters/CompareByIndex.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/opgraph/op3rewriters/CompareByIndex.java
@@ -22,7 +22,7 @@ public class CompareByIndex implements Comparator<Op03SimpleStatement> {
         int res = a.getIndex().compareTo(b.getIndex());
         if (!asc) res = -res;
         if (res == 0) {
-            throw new ConfusedCFRException("Can't sort instructions:\n" + a + "\n" + b);
+            throw new ConfusedCFRException("Can't sort instructions [" + a + ", " + b + "]");
         }
         //noinspection ComparatorMethodParameterNotUsed
         return res;

--- a/src/org/benf/cfr/reader/bytecode/analysis/structured/statement/StructuredFakeDecompFailure.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/structured/statement/StructuredFakeDecompFailure.java
@@ -16,11 +16,13 @@ public class StructuredFakeDecompFailure extends StructuredComment {
         dumper.indent(1);
         dumper.newln();
         dumper.beginBlockComment(false);
-        dumper.print("This method has failed to decompile.  When submitting a bug report, please provide this stack trace, and (if you hold appropriate legal rights) the relevant class file.").newln();
+        dumper.print("This method has failed to decompile.  When submitting a bug report, please provide this stack trace, and (if you hold appropriate legal rights) the relevant class file.").newln().newln();
         dumper.print(e.toString()).newln();
+        dumper.indent(1);
         for (StackTraceElement ste : e.getStackTrace()) {
-            dumper.print(ste.toString()).newln();
+            dumper.print("at ").print(ste.toString()).newln();
         }
+        dumper.indent(-1);
         dumper.endBlockComment();
         dumper.keyword("throw new ").print("IllegalStateException").separator("(").literal("\"Decompilation failed\"", "\"Decompilation failed\"").separator(")").endCodeln();
         dumper.indent(-1);

--- a/src/org/benf/cfr/reader/util/output/AbstractDumper.java
+++ b/src/org/benf/cfr/reader/util/output/AbstractDumper.java
@@ -26,12 +26,12 @@ abstract class AbstractDumper implements Dumper {
 
     @Override
     public Dumper endBlockComment() {
-
         if (context.inBlockComment == BlockCommentState.Not) {
             throw new IllegalStateException("Attempt to end block comment when not in one.");
         }
         BlockCommentState old = context.inBlockComment;
         context.inBlockComment = BlockCommentState.Not;
+        context.blockCommentIndent = 0;
         if (old == BlockCommentState.In) {
             if (!context.atStart) {
                 newln();
@@ -77,7 +77,7 @@ abstract class AbstractDumper implements Dumper {
 
     @Override
     public int getIndentLevel() {
-        return context.indent;
+        return context.indent + context.blockCommentIndent;
     }
 
     @Override

--- a/src/org/benf/cfr/reader/util/output/MovableDumperContext.java
+++ b/src/org/benf/cfr/reader/util/output/MovableDumperContext.java
@@ -5,6 +5,7 @@ class MovableDumperContext {
     boolean atStart = true;
     boolean pendingCR = false;
     int indent;
+    int blockCommentIndent;
     int outputCount = 0;
     int currentLine = 1; // lines are 1 based.  Sigh.
 }

--- a/src/org/benf/cfr/reader/util/output/StreamDumper.java
+++ b/src/org/benf/cfr/reader/util/output/StreamDumper.java
@@ -185,11 +185,6 @@ public abstract class StreamDumper extends AbstractDumper {
     }
 
     @Override
-    public int getIndentLevel() {
-        return context.indent + context.blockCommentIndent;
-    }
-
-    @Override
     public Dumper fieldName(String name, JavaTypeInstance owner, boolean hiddenDeclaration, boolean isStatic, boolean defines) {
         identifier(name, null, defines);
         return this;

--- a/src/org/benf/cfr/reader/util/output/StreamDumper.java
+++ b/src/org/benf/cfr/reader/util/output/StreamDumper.java
@@ -160,7 +160,10 @@ public abstract class StreamDumper extends AbstractDumper {
         String indents = "    ";
         for (int x = 0; x < context.indent; ++x) write(indents);
         context.atStart = false;
-        if (context.inBlockComment != BlockCommentState.Not) write (" * ");
+        if (context.inBlockComment != BlockCommentState.Not) {
+            write (" * ");
+            for (int x = 0; x < context.blockCommentIndent; ++x) write(indents);
+        }
     }
 
     private void processPendingCR() {
@@ -174,12 +177,16 @@ public abstract class StreamDumper extends AbstractDumper {
 
     @Override
     public void indent(int diff) {
-        context.indent += diff;
+        if (context.inBlockComment == BlockCommentState.Not) {
+            context.indent += diff;
+        } else {
+            context.blockCommentIndent += diff;
+        }
     }
 
     @Override
     public int getIndentLevel() {
-        return context.indent;
+        return context.indent + context.blockCommentIndent;
     }
 
     @Override

--- a/src/org/benf/cfr/reader/util/output/ToStringDumper.java
+++ b/src/org/benf/cfr/reader/util/output/ToStringDumper.java
@@ -122,12 +122,19 @@ public class ToStringDumper extends AbstractDumper {
         String indents = "    ";
         for (int x = 0; x < context.indent; ++x) sb.append(indents);
         context.atStart = false;
-        if (context.inBlockComment != BlockCommentState.Not) sb.append(" * ");
+        if (context.inBlockComment != BlockCommentState.Not) {
+            sb.append(" * ");
+            for (int x = 0; x < context.blockCommentIndent; ++x) sb.append(indents);
+        }
     }
 
     @Override
     public void indent(int diff) {
-        context.indent += diff;
+        if (context.inBlockComment == BlockCommentState.Not) {
+            context.indent += diff;
+        } else {
+            context.blockCommentIndent += diff;
+        }
     }
 
     @Override


### PR DESCRIPTION
Exceptions will be formatted similar to how `printStackTrace` does it.

Example before:
```Java
    public EnumSwitchTest2() {
        /*
         * This method has failed to decompile.  When submitting a bug report, please provide this stack trace, and (if you hold appropriate legal rights) the relevant class file.
         * org.benf.cfr.reader.util.ConfusedCFRException: test
         * org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisInner(CodeAnalyser.java:276)
         * org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisOrWrapFail(CodeAnalyser.java:262)
         * org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysis(CodeAnalyser.java:196)
         * org.benf.cfr.reader.entities.attributes.AttributeCode.analyse(AttributeCode.java:94)
         * org.benf.cfr.reader.entities.Method.analyse(Method.java:527)
         * org.benf.cfr.reader.entities.ClassFile.analyseMid(ClassFile.java:1042)
         * org.benf.cfr.reader.entities.ClassFile.analyseTop(ClassFile.java:929)
         * org.benf.cfr.reader.Driver.doClass(Driver.java:83)
         * org.benf.cfr.reader.CfrDriverImpl.analyse(CfrDriverImpl.java:75)
         * org.benf.cfr.reader.Main.main(Main.java:49)
         */
        throw new IllegalStateException("Decompilation failed");
    }
```
Example after:
```Java
    public EnumSwitchTest2() {
        /*
         * This method has failed to decompile.  When submitting a bug report, please provide this stack trace, and (if you hold appropriate legal rights) the relevant class file.
         * 
         * org.benf.cfr.reader.util.ConfusedCFRException: test
         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisInner(CodeAnalyser.java:276)
         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysisOrWrapFail(CodeAnalyser.java:262)
         *     at org.benf.cfr.reader.bytecode.CodeAnalyser.getAnalysis(CodeAnalyser.java:196)
         *     at org.benf.cfr.reader.entities.attributes.AttributeCode.analyse(AttributeCode.java:94)
         *     at org.benf.cfr.reader.entities.Method.analyse(Method.java:527)
         *     at org.benf.cfr.reader.entities.ClassFile.analyseMid(ClassFile.java:1042)
         *     at org.benf.cfr.reader.entities.ClassFile.analyseTop(ClassFile.java:929)
         *     at org.benf.cfr.reader.Driver.doClass(Driver.java:83)
         *     at org.benf.cfr.reader.CfrDriverImpl.analyse(CfrDriverImpl.java:75)
         *     at org.benf.cfr.reader.Main.main(Main.java:49)
         */
        throw new IllegalStateException("Decompilation failed");
    }
```