### PR TITLE
Anti-Obfuscation: Integer Inlining

### DIFF
--- a/src/org/benf/cfr/reader/bytecode/analysis/opgraph/Op02WithProcessedDataAndRefs.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/opgraph/Op02WithProcessedDataAndRefs.java
@@ -162,13 +162,13 @@ public class Op02WithProcessedDataAndRefs implements Dumpable, Graph<Op02WithPro
     }
 
     @SuppressWarnings("SameParameterValue")
-    private int getInstrArgByte(int index) {
+    public int getInstrArgByte(int index) {
         return rawData[index];
     }
 
     // Cheap unsigned byte read, save constructing a baseByteData.
     @SuppressWarnings("SameParameterValue")
-    public int getInstrArgU1(int index) {
+    private int getInstrArgU1(int index) {
         int res = rawData[index];
         if (res < 0) {
             res = 256 + res;

--- a/src/org/benf/cfr/reader/bytecode/analysis/opgraph/Op02WithProcessedDataAndRefs.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/opgraph/Op02WithProcessedDataAndRefs.java
@@ -181,6 +181,11 @@ public class Op02WithProcessedDataAndRefs implements Dumpable, Graph<Op02WithPro
         return tmp.getS2At(index);
     }
 
+    public int getInstrArgInt(int index) {
+        BaseByteData tmp = new BaseByteData(rawData);
+        return tmp.getS4At(index);
+    }
+
     @Override
     public List<Op02WithProcessedDataAndRefs> getTargets() {
         return targets;

--- a/src/org/benf/cfr/reader/bytecode/analysis/opgraph/Op02WithProcessedDataAndRefs.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/opgraph/Op02WithProcessedDataAndRefs.java
@@ -168,7 +168,7 @@ public class Op02WithProcessedDataAndRefs implements Dumpable, Graph<Op02WithPro
 
     // Cheap unsigned byte read, save constructing a baseByteData.
     @SuppressWarnings("SameParameterValue")
-    private int getInstrArgU1(int index) {
+    public int getInstrArgU1(int index) {
         int res = rawData[index];
         if (res < 0) {
             res = 256 + res;
@@ -176,7 +176,7 @@ public class Op02WithProcessedDataAndRefs implements Dumpable, Graph<Op02WithPro
         return res;
     }
 
-    private int getInstrArgShort(int index) {
+    public int getInstrArgShort(int index) {
         BaseByteData tmp = new BaseByteData(rawData);
         return tmp.getS2At(index);
     }

--- a/src/org/benf/cfr/reader/bytecode/analysis/opgraph/op02obf/ControlFlowNumericObf.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/opgraph/op02obf/ControlFlowNumericObf.java
@@ -4,10 +4,13 @@ import org.benf.cfr.reader.bytecode.analysis.opgraph.Op02WithProcessedDataAndRef
 import org.benf.cfr.reader.bytecode.analysis.parse.utils.Pair;
 import org.benf.cfr.reader.bytecode.opcode.JVMInstr;
 import org.benf.cfr.reader.entities.Method;
+import org.benf.cfr.reader.entities.constantpool.ConstantPool;
+import org.benf.cfr.reader.entities.constantpool.ConstantPoolEntry;
+import org.benf.cfr.reader.entities.constantpool.ConstantPoolEntryInteger;
+import org.benf.cfr.reader.entities.constantpool.ConstantPoolEntryLong;
+import org.benf.cfr.reader.util.bytestream.BaseByteData;
 
-import java.io.ByteArrayOutputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 /*
@@ -63,26 +66,50 @@ public class ControlFlowNumericObf {
     }
 
     private void processTwo(Op02WithProcessedDataAndRefs op, List<Op02WithProcessedDataAndRefs> op2list, int idx) {
+        List<Op02WithProcessedDataAndRefs> toRemove = new ArrayList<Op02WithProcessedDataAndRefs>();
         Op02WithProcessedDataAndRefs prev1 = op.getSources().get(0);
         Op02WithProcessedDataAndRefs prev2 = prev1.getSources().get(0);
-        if (!isIntConstant(prev1.getInstr())) return;
-        if (!isIntConstant(prev2.getInstr())) return;
-        int v1 = getConstValue(prev1);
-        int v2 = getConstValue(prev2);
-        int value = doMath(op.getInstr(), v1, v2);
+        toRemove.add(prev1);
+        toRemove.add(prev2);
+        while (isProxy(prev1)) {
+            prev1 = prev1.getSources().get(0);
+            prev2 = prev2.getSources().get(0);
+            toRemove.add(prev2);
+        }
+        while (isProxy(prev2)) {
+            prev2 = prev2.getSources().get(0);
+            toRemove.add(prev2);
+        }
+        if (!isNumericConstant(prev1.getInstr())) return;
+        if (!isNumericConstant(prev2.getInstr())) return;
+        long v1 = getConstValue(prev1);
+        long v2 = getConstValue(prev2);
+        long value = doMath(op.getInstr(), v1, v2);
         // don't mutate the data, that's shared between passes - create new.
         Op02WithProcessedDataAndRefs replace;
-        if (value > Short.MAX_VALUE || value < Short.MIN_VALUE) {
+        if (value > Integer.MAX_VALUE || value < Integer.MIN_VALUE) {
+            int index = addLongToCp(op.getCp(), value);
+            replace = new Op02WithProcessedDataAndRefs(
+                    JVMInstr.LDC2_W,
+                    new byte[]{
+                            (byte)(index >>> 8 & 0xFF),
+                            (byte)(index & 0xFF)},
+                    op.getIndex(),
+                    op.getCp(),
+                    new ConstantPoolEntry[]{op.getCp().getEntry(index)},
+                    op.getOriginalRawOffset(),
+                    op.getBytecodeLoc()
+            );
+        } else if (value > Short.MAX_VALUE || value < Short.MIN_VALUE) {
+            int index = addLongToCp(op.getCp(), value);
             replace = new Op02WithProcessedDataAndRefs(
                     JVMInstr.LDC,
                     new byte[]{
-                            (byte) (value >>> 24 & 0xFF),
-                            (byte) (value >>> 16 & 0xFF),
-                            (byte) (value >>> 8 & 0xFF),
-                            (byte) (value & 0xFF)},
+                            (byte)(index >>> 8 & 0xFF),
+                            (byte)(index & 0xFF)},
                     op.getIndex(),
                     op.getCp(),
-                    null,
+                    new ConstantPoolEntry[]{op.getCp().getEntry(index)},
                     op.getOriginalRawOffset(),
                     op.getBytecodeLoc()
             );
@@ -90,8 +117,8 @@ public class ControlFlowNumericObf {
             replace = new Op02WithProcessedDataAndRefs(
                     JVMInstr.SIPUSH,
                     new byte[]{
-                            (byte) (value >>> 8 & 0xFF),
-                            (byte) (value & 0xFF)},
+                            (byte)(value >>> 8 & 0xFF),
+                            (byte)(value & 0xFF)},
                     op.getIndex(),
                     op.getCp(),
                     null,
@@ -102,28 +129,57 @@ public class ControlFlowNumericObf {
 
         op2list.set(idx, replace);
         Op02WithProcessedDataAndRefs.replace(op, replace);
-        prev1.nop();
-        prev2.nop();
+        for (Op02WithProcessedDataAndRefs removable : toRemove) {
+            removable.nop();
+        }
     }
 
-    private int doMath(JVMInstr instr, int arg1, int arg2) {
+    private int addLongToCp(ConstantPool cp, long value) {
+        return cp.addEntry(new ConstantPoolEntryLong(cp, new BaseByteData(new byte[]{
+                0,
+                (byte)((int)(value >>> 56)),
+                (byte)((int)(value >>> 48)),
+                (byte)((int)(value >>> 40)),
+                (byte)((int)(value >>> 32)),
+                (byte)((int)(value >>> 24)),
+                (byte)((int)(value >>> 16)),
+                (byte)((int)(value >>> 8)),
+                (byte)((int)(value)),
+        })));
+    }
+
+    private boolean isProxy(Op02WithProcessedDataAndRefs op) {
+        JVMInstr instr = op.getInstr();
+        return instr == JVMInstr.I2L;
+    }
+
+    private long doMath(JVMInstr instr, long arg1, long arg2) {
         switch (instr) {
+            case LXOR:
             case IXOR:
                 return arg2 ^ arg1;
+            case LOR:
             case IOR:
                 return arg2 | arg1;
+            case LAND:
             case IAND:
                 return arg2 & arg1;
+            case LADD:
             case IADD:
                 return arg2 + arg1;
+            case LSUB:
             case ISUB:
                 return arg2 - arg1;
+            case LMUL:
             case IMUL:
                 return arg2 * arg1;
+            case LDIV:
             case IDIV:
                 return arg2 / arg1;
+            case LSHL:
             case ISHL:
                 return arg2 << arg1;
+            case LSHR:
             case ISHR:
                 return arg2 >> arg1;
             default:
@@ -131,15 +187,17 @@ public class ControlFlowNumericObf {
         }
     }
 
-    private int getConstValue(Op02WithProcessedDataAndRefs op) {
+    private long getConstValue(Op02WithProcessedDataAndRefs op) {
         JVMInstr instr = op.getInstr();
         if (instr == JVMInstr.BIPUSH) {
             return op.getInstrArgByte(0);
+        } else if (instr == JVMInstr.SIPUSH) {
+            return op.getInstrArgShort(0);
         } else if (instr == JVMInstr.ICONST_M1) {
             return -1;
-        } else if (instr == JVMInstr.ICONST_0) {
+        } else if (instr == JVMInstr.ICONST_0 || instr == JVMInstr.LCONST_0) {
             return 0;
-        } else if (instr == JVMInstr.ICONST_1) {
+        } else if (instr == JVMInstr.ICONST_1 || instr == JVMInstr.LCONST_1) {
             return 1;
         } else if (instr == JVMInstr.ICONST_2) {
             return 2;
@@ -149,17 +207,35 @@ public class ControlFlowNumericObf {
             return 4;
         } else if (instr == JVMInstr.ICONST_5) {
             return 5;
+        } else if (instr == JVMInstr.LDC || instr == JVMInstr.LDC_W || instr == JVMInstr.LDC2_W) {
+            ConstantPoolEntry value = op.getCpEntries()[0];
+            if (value instanceof ConstantPoolEntryInteger) {
+                return ((ConstantPoolEntryInteger) value).getValue();
+            } else if (value instanceof ConstantPoolEntryLong) {
+                return ((ConstantPoolEntryLong) value).getValue();
+            }
         }
-        return op.getInstrArgShort(0);
+        throw new UnsupportedOperationException("Unsupported constant value holder");
     }
 
-    private boolean isIntConstant(JVMInstr instr) {
-        return instr == JVMInstr.SIPUSH || instr == JVMInstr.BIPUSH || instr == JVMInstr.LDC;
+    /*
+     * We do not have to check here for the contents of LDC since we are operating under the assumption
+     * that they provide arguments for a math operation. Providing a non-numeric value would be illegal.
+     */
+    private boolean isNumericConstant(JVMInstr instr) {
+        return instr == JVMInstr.SIPUSH || instr == JVMInstr.BIPUSH || instr == JVMInstr.ICONST_M1
+                || instr == JVMInstr.ICONST_0 || instr == JVMInstr.ICONST_1 || instr == JVMInstr.ICONST_2
+                || instr == JVMInstr.ICONST_3 || instr == JVMInstr.ICONST_4 || instr == JVMInstr.ICONST_5
+                || instr == JVMInstr.LCONST_0 || instr == JVMInstr.LCONST_1 || instr == JVMInstr.LDC
+                || instr == JVMInstr.LDC_W || instr == JVMInstr.LDC2_W;
     }
 
     private boolean isIntMath(JVMInstr instr) {
         return instr == JVMInstr.IXOR || instr == JVMInstr.IOR || instr == JVMInstr.IAND
                 || instr == JVMInstr.IADD || instr == JVMInstr.ISUB || instr == JVMInstr.IMUL
-                || instr == JVMInstr.IDIV || instr == JVMInstr.ISHL || instr == JVMInstr.ISHR;
+                || instr == JVMInstr.IDIV || instr == JVMInstr.ISHL || instr == JVMInstr.ISHR
+                || instr == JVMInstr.LXOR || instr == JVMInstr.LOR || instr == JVMInstr.LAND
+                || instr == JVMInstr.LADD || instr == JVMInstr.LSUB || instr == JVMInstr.LMUL
+                || instr == JVMInstr.LDIV || instr == JVMInstr.LSHL || instr == JVMInstr.LSHR;
     }
 }

--- a/src/org/benf/cfr/reader/bytecode/analysis/opgraph/op02obf/ControlFlowNumericObf.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/opgraph/op02obf/ControlFlowNumericObf.java
@@ -5,13 +5,21 @@ import org.benf.cfr.reader.bytecode.analysis.parse.utils.Pair;
 import org.benf.cfr.reader.bytecode.opcode.JVMInstr;
 import org.benf.cfr.reader.entities.Method;
 
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
 import java.util.List;
 
 /*
- * Java integers just wrap around, so obfuscating heedlessly with
+ * This covers two cases:
+ *
+ * 1: Java integers just wrap around, so obfuscating heedlessly with
  * i += 2  --> i += 100 ; i -= 98;
  * is perfectly safe.
  * It's not much of an obfuscation, but worth undoing.
+ *
+ * 2: Its common to use simple math operations to hide constants
+ * i += 2 --> i += ((241 ^ 147) + 2) / 50
  */
 public class ControlFlowNumericObf {
     public static ControlFlowNumericObf Instance = new ControlFlowNumericObf();
@@ -22,6 +30,8 @@ public class ControlFlowNumericObf {
             JVMInstr instr = op.getInstr();
             if (instr == JVMInstr.IINC) {
                 processOne(op, op2list, idx);
+            } else if (isIntMath(instr)) {
+                processTwo(op, op2list, idx);
             }
         }
     }
@@ -50,5 +60,86 @@ public class ControlFlowNumericObf {
             Op02WithProcessedDataAndRefs.replace(op, replace);
             next.nop();
         }
+    }
+
+    private void processTwo(Op02WithProcessedDataAndRefs op, List<Op02WithProcessedDataAndRefs> op2list, int idx) {
+        Op02WithProcessedDataAndRefs prev1 = op2list.get(idx - 1);
+        Op02WithProcessedDataAndRefs prev2 = op2list.get(idx - 2);
+        if (!isIntConstant(prev1.getInstr())) return;
+        if (!isIntConstant(prev2.getInstr())) return;
+        int v1 = getConstValue(prev1);
+        int v2 = (prev2.getInstr() == JVMInstr.BIPUSH) ? prev2.getInstrArgU1(0) : prev2.getInstrArgShort(0);;
+        int value = doMath(op.getInstr(), v1, v2);
+        // don't mutate the data, that's shared between passes - create new.
+        Op02WithProcessedDataAndRefs replace = new Op02WithProcessedDataAndRefs(
+                JVMInstr.SIPUSH,
+                new byte[]{(byte)(value >>> 8 & 0xFF), (byte)(value & 0xFF)},
+                op.getIndex(),
+                op.getCp(),
+                null,
+                op.getOriginalRawOffset(),
+                op.getBytecodeLoc()
+        );
+        op2list.set(idx, replace);
+        Op02WithProcessedDataAndRefs.replace(op, replace);
+        prev1.nop();
+        prev2.nop();
+    }
+
+    private int doMath(JVMInstr instr, int arg1, int arg2) {
+        switch (instr) {
+            case IXOR:
+                return arg1 ^ arg2;
+            case IOR:
+                return arg1 | arg2;
+            case IAND:
+                return arg1 & arg2;
+            case IADD:
+                return arg1 + arg2;
+            case ISUB:
+                return arg1 - arg2;
+            case IMUL:
+                return arg1 * arg2;
+            case IDIV:
+                return arg1 / arg2;
+            case ISHL:
+                return arg1 << arg2;
+            case ISHR:
+                return arg1 >> arg2;
+            default:
+                throw new IllegalStateException();
+        }
+    }
+
+    private int getConstValue(Op02WithProcessedDataAndRefs prev1) {
+        JVMInstr instr = prev1.getInstr();
+        if (instr == JVMInstr.BIPUSH) {
+            return prev1.getInstrArgU1(0);
+        } else if (instr == JVMInstr.ICONST_M1) {
+            return -1;
+        } else if (instr == JVMInstr.ICONST_0) {
+            return 0;
+        } else if (instr == JVMInstr.ICONST_1) {
+            return 1;
+        } else if (instr == JVMInstr.ICONST_2) {
+            return 2;
+        } else if (instr == JVMInstr.ICONST_3) {
+            return 3;
+        } else if (instr == JVMInstr.ICONST_4) {
+            return 4;
+        } else if (instr == JVMInstr.ICONST_5) {
+            return 5;
+        }
+        return prev1.getInstrArgShort(0);
+    }
+
+    private boolean isIntConstant(JVMInstr instr) {
+        return instr == JVMInstr.SIPUSH || instr == JVMInstr.BIPUSH || instr == JVMInstr.LDC;
+    }
+
+    private boolean isIntMath(JVMInstr instr) {
+        return instr == JVMInstr.IXOR || instr == JVMInstr.IOR || instr == JVMInstr.IAND
+                || instr == JVMInstr.IADD || instr == JVMInstr.ISUB || instr == JVMInstr.IMUL
+                || instr == JVMInstr.IDIV || instr == JVMInstr.ISHL || instr == JVMInstr.ISHR;
     }
 }

--- a/src/org/benf/cfr/reader/entities/constantpool/ConstantPool.java
+++ b/src/org/benf/cfr/reader/entities/constantpool/ConstantPool.java
@@ -16,7 +16,7 @@ import java.util.logging.Logger;
 public class ConstantPool {
     private static final Logger logger = LoggerFactory.create(ConstantPool.class);
 
-    private final long length;
+    private long length;
     private final List<ConstantPoolEntry> entries;
     private final Options options;
     private final DCCommonState dcCommonState;
@@ -26,7 +26,7 @@ public class ConstantPool {
     private boolean isLoaded;
     private final int idx = sidx++;
     private static int sidx = 0;
-    private final boolean dynamicConstants;
+    private boolean dynamicConstants;
 
     public ConstantPool(ClassFile classFile, DCCommonState dcCommonState, ByteData raw, int count) {
         this.classFile = classFile;
@@ -148,6 +148,17 @@ public class ConstantPool {
 
     public long getRawByteLength() {
         return length;
+    }
+
+    public int addEntry(ConstantPoolEntry entry) {
+        length += entry.getRawByteLength();
+        dynamicConstants |= entry instanceof ConstantPoolEntryDynamicInfo;
+        entries.add(entry);
+        int index = entries.size();
+        if (entry instanceof ConstantPoolEntryLong || entry instanceof ConstantPoolEntryDouble) {
+            entries.add(null);
+        }
+        return index;
     }
 
     public ConstantPoolEntry getEntry(int index) {


### PR DESCRIPTION
Inspired by the latest few commits I thought I'd try my hand at further reducing redundant integer patterns. 

Examples (Using `obfcontrol` set to `true`)
```java
// IXOR
public static int fibonacci(int n) {
    if (n <= (0x67DA ^ 0xFFFFE265 ^ 0x6184 ^ 0xFFFFE43A)) {
        return n;
    }
    return fibonacci(n - (0xBBB ^ 0xFFFFE60B ^ 0x65F2 ^ 0xFFFF8843)) + fibonacci(n - (0x7AD6 ^ 0xFFFFA6F2 ^ 0x66B2 ^ 0xFFFFBA94));
}
// ISUB + IADD
public static int fibonacci(int n) {
    if (n <= 36 - 40 + 26 - 15 - 6) {
        return n;
    }
    return fibonacci(n - (208 - 355 + 353 - 245 + 40)) + fibonacci(n - (223 - 412 + 193 - 2));
}
// I2L + LXOR + L2I
public static int fibonacci(int n) {
    if (n <= (int)((long)2108268340 ^ (long)2108268341)) {
        return n;
    }
    return fibonacci(n - (int)((long)864501408 ^ (long)864501409)) + fibonacci(n - (int)((long)1741113313 ^ (long)1741113315));
}
```
Cleaned output
```java
public static int fibonacci(int n) {
    if (n <= 1) {
        return n;
    }
     return fibonacci(n - 1) + fibonacci(n - 2);
}
```

***

Samples: 

- https://github.com/GenericException/SkidSuite/blob/master/obf/Scuti/Num2/output.jar
- https://github.com/GenericException/SkidSuite/blob/master/obf/Radon/samples/1.0.3/Num1/output.jar
- https://github.com/GenericException/SkidSuite/blob/master/obf/Radon/samples/1.0.3/Num3/output.jar

***

cfr_tests: I ran against the Java 8 set comparing bb4a71ac4a81e5a06a4fb8f34b32d32198f19697 to this branch, no diffs detected.

***

Design: I recognize that I had to add make the constant pool modifiable in order to support inlining of `long` values. If there is a better approach I'd be happy to improve.