### PR TITLE
add external classFileSource to the CFR driver

### DIFF
--- a/src/org/benf/cfr/reader/CfrDriverImpl.java
+++ b/src/org/benf/cfr/reader/CfrDriverImpl.java
@@ -45,6 +45,11 @@ public class CfrDriverImpl implements CfrDriver {
 
     @Override
     public void analyse(List<String> toAnalyse) {
+        analyse(toAnalyse,null);
+    }
+
+    @Override
+    public void analyse(List<String> toAnalyse, ClassFileSource externalFileSource) {
         /*
          * There's an interesting question here - do we want to skip inner classes, if we've been given a wildcard?
          * (or a wildcard expanded by the operating system).
@@ -59,7 +64,7 @@ public class CfrDriverImpl implements CfrDriver {
             // it causes test fails.  (used class name table retains useful symbols).
             classFileSource.informAnalysisRelativePathDetail(null, null);
             // Note - both of these need to be reset, as they have caches.
-            DCCommonState dcCommonState = new DCCommonState(options, classFileSource);
+            DCCommonState dcCommonState = new DCCommonState(options, classFileSource, externalFileSource);
             DumperFactory dumperFactory = outputSinkFactory != null ?
                     new SinkDumperFactory(outputSinkFactory, options) :
                     new InternalDumperFactoryImpl(options);

--- a/src/org/benf/cfr/reader/Main.java
+++ b/src/org/benf/cfr/reader/Main.java
@@ -46,6 +46,6 @@ public class Main {
         }
 
         CfrDriver cfrDriver = new CfrDriver.Builder().withBuiltOptions(options).build();
-        cfrDriver.analyse(files);
+        cfrDriver.analyse(files,null);
     }
 }

--- a/src/org/benf/cfr/reader/PluginRunner.java
+++ b/src/org/benf/cfr/reader/PluginRunner.java
@@ -124,7 +124,7 @@ public class PluginRunner {
         ClassFileSource2 source = classFileSource == null ?
                 new ClassFileSourceImpl(options) :
                 new ClassFileSourceWrapper(classFileSource);
-        return new DCCommonState(options, source);
+        return new DCCommonState(options, source,null);
     }
 
 }

--- a/src/org/benf/cfr/reader/api/CfrDriver.java
+++ b/src/org/benf/cfr/reader/api/CfrDriver.java
@@ -17,6 +17,14 @@ public interface CfrDriver {
      * Analyse and dump to configured output sink.
      *
      * @param toAnalyse list of class file FQN / path of jar / path of class file
+     * @param externalFileSource implementation of ClassFileSource to find class dependencies
+     */
+    void analyse(List<String> toAnalyse, ClassFileSource externalFileSource);
+
+    /**
+     * Analyse and dump to configured output sink.
+     *
+     * @param toAnalyse list of class file FQN / path of jar / path of class file
      */
     void analyse(List<String> toAnalyse);
 


### PR DESCRIPTION
Added an external file source to the interface, to allow CFR to find dependent classes that are not part of the current classpath or in an added jar.