### PR TITLE
Fix javadocs on annotation classes

### DIFF
--- a/src/org/benf/cfr/reader/entities/classfilehelpers/ClassFileDumperAnnotation.java
+++ b/src/org/benf/cfr/reader/entities/classfilehelpers/ClassFileDumperAnnotation.java
@@ -36,6 +36,7 @@ public class ClassFileDumperAnnotation extends AbstractClassFileDumper {
         }
 
         boolean first = true;
+        dumpComments(classFile, d);
         dumpAnnotations(classFile, d);
         dumpHeader(classFile, innerClass, d);
         d.separator("{").newln();


### PR DESCRIPTION
Javadocs were not showing in annotation classes, this PR fixes it