### PR TITLE
Fix ConstantLinks using wrong class for relinking fields

### DIFF
--- a/src/org/benf/cfr/reader/entities/classfilehelpers/ConstantLinks.java
+++ b/src/org/benf/cfr/reader/entities/classfilehelpers/ConstantLinks.java
@@ -88,10 +88,10 @@ public class ConstantLinks {
                 Object o = lit == null ? null : lit.getValue();
                 if (o == null) continue;
                 // duplicate value for val? Leave null & poison it.
-                addOrPoison(classFile, expfact, rewrites, local, f, o);
+                addOrPoison(currClass, expfact, rewrites, local, f, o);
                 // A few hacks
                 if (lit.getType() == TypedLiteral.LiteralType.Integer) {
-                    addOrPoison(classFile, expfact, spares, local, f, (double)lit.getIntValue());
+                    addOrPoison(currClass, expfact, spares, local, f, (double)lit.getIntValue());
                 }
             }
             if (currClass.isInnerClass()) {


### PR DESCRIPTION
Previously the current class was used as declaring class; that resulted in correct code if the current class is a nested class which does not extend the class declaring the field, or if the current class is anonymous (would result in <code>1.<i>field</i></code>).

Example code:
```java
class RelinkingTest {
    public static final String CONSTANT = "test";
    
    Object o = new Object() {
        @Override
        public String toString() {
            return CONSTANT;
        }
    };
    
    class Nested {
        @Override
        public String toString() {
            return CONSTANT;
        }
    }
}
```

Decompiled output:
```java
class RelinkingTest {
    public static final String CONSTANT = "test";
    Object o = new Object(){

        public String toString() {
            return _1.CONSTANT;
        }
    };

    RelinkingTest() {
    }

    class Nested {
        Nested() {
        }

        public String toString() {
            return Nested.CONSTANT;
        }
    }
}
```