### PR TITLE
Minor changes: add the --version option and slightly improve the help hint

### DIFF
--- a/src/org/benf/cfr/reader/Main.java
+++ b/src/org/benf/cfr/reader/Main.java
@@ -45,6 +45,11 @@ public class Main {
             return;
         }
 
+        if (options.optionIsSet(OptionsImpl.VERSION)) {
+            getOptParser.showVersion();
+            return;
+        }
+
         CfrDriver cfrDriver = new CfrDriver.Builder().withBuiltOptions(options).build();
         cfrDriver.analyse(files);
     }

--- a/src/org/benf/cfr/reader/util/getopt/GetOptParser.java
+++ b/src/org/benf/cfr/reader/util/getopt/GetOptParser.java
@@ -93,7 +93,7 @@ public class GetOptParser {
          * A bit of a hack, but if no positional arguments are specified, and 'help' is, then
          * we don't want to blow up, so work around this.
          */
-        if (positional.isEmpty() && named.containsKey(OptionsImpl.HELP.getName())) {
+        if (positional.isEmpty() && (named.containsKey(OptionsImpl.HELP.getName()) || named.containsKey(OptionsImpl.VERSION.getName()))) {
             positional.add("ignoreMe.class");
         }
         T res = getOptSinkFactory.create(named);
@@ -106,6 +106,10 @@ public class GetOptParser {
 
     private static void printUsage() {
         System.err.println("java -jar CFRJAR.jar class_or_jar_file [method] [options]\n");
+    }
+
+    public void showVersion() {
+        printErrHeader();
     }
 
     public void showHelp(Exception e) {
@@ -154,7 +158,7 @@ public class GetOptParser {
                     String value;
                     if (next.startsWith(argPrefix)) {
                         // Does it have a default?
-                        if (name.equals(OptionsImpl.HELP.getName())) {
+                        if (name.equals(OptionsImpl.HELP.getName()) || name.equals(OptionsImpl.VERSION.getName())) {
                             value = "";
                         } else {
                             value = optData.getArgument().getFn().getDefaultValue();

--- a/src/org/benf/cfr/reader/util/getopt/GetOptParser.java
+++ b/src/org/benf/cfr/reader/util/getopt/GetOptParser.java
@@ -108,6 +108,10 @@ public class GetOptParser {
         System.err.println("java -jar CFRJAR.jar class_or_jar_file [method] [options]\n");
     }
 
+    private static void printHelpHint(boolean full) {
+        System.err.println("Please specify " + ( full ? "'--help' to get option list, or " : "" ) + "'--help optionname' for specifics, e.g.\n   --help " + OptionsImpl.PULL_CODE_CASE.getName());
+    }
+
     public void showVersion() {
         printErrHeader();
     }
@@ -116,7 +120,7 @@ public class GetOptParser {
         printErrHeader();
         printUsage();
         System.err.println("Parameter error : " + e.getMessage() + "\n");
-        System.err.println("Please specify '--help' to get option list, or '--help optionname' for specifics, e.g.\n   --help " + OptionsImpl.PULL_CODE_CASE.getName());
+        printHelpHint(true);
     }
 
     public void showOptionHelp(PermittedOptionProvider permittedOptionProvider, Options options, PermittedOptionProvider.ArgumentParam<String, Void> helpArg) {
@@ -131,7 +135,7 @@ public class GetOptParser {
         }
         System.err.println(getHelp(permittedOptionProvider));
         if (relevantOption.equals("")) {
-            System.err.println("Please specify '--help optionname' for specifics, eg\n   --help " + OptionsImpl.PULL_CODE_CASE.getName());
+            printHelpHint(false);
         } else {
             System.err.println("No such argument '" + relevantOption + "'");
         }

--- a/src/org/benf/cfr/reader/util/getopt/OptionsImpl.java
+++ b/src/org/benf/cfr/reader/util/getopt/OptionsImpl.java
@@ -475,6 +475,9 @@ public class OptionsImpl implements Options {
     public static final PermittedOptionProvider.ArgumentParam<Boolean, ClassFileVersion> SHOW_INFERRABLE = register(new PermittedOptionProvider.ArgumentParam<Boolean, ClassFileVersion>(
             "showinferrable", new VersionSpecificDefaulter(ClassFileVersion.JAVA_7, false),
             "Decorate methods with explicit types if not implied by arguments"));
+    public static final PermittedOptionProvider.Argument<Boolean> VERSION = register(new PermittedOptionProvider.Argument<Boolean>(
+            "version", defaultTrueBooleanDecoder,
+            "Show the current CFR version"));
     public static final PermittedOptionProvider.Argument<String> HELP = register(new PermittedOptionProvider.Argument<String>(
             "help", defaultNullStringDecoder,
             "Show help for a given parameter"));


### PR DESCRIPTION
I am not sure that my suggestions are fully covered by the project contributing guideline. Nevertheless I'd like to post them here. In fact, there are two small commits:

* add --version option
  Many tools (and JVM itself) have the option for printing its version. I hope it can be useful for CFR as well.
* unify help hint outputs
  While working on the first commit I found that two hints look almost identical with some differences. So I combined them into a single method.
