### PR TITLE
Output record type parameters when dumping record classes

### DIFF
--- a/src/org/benf/cfr/reader/entities/classfilehelpers/ClassFileDumperRecord.java
+++ b/src/org/benf/cfr/reader/entities/classfilehelpers/ClassFileDumperRecord.java
@@ -25,7 +25,9 @@ public class ClassFileDumperRecord extends AbstractClassFileDumper {
     private void dumpHeader(ClassFile c, InnerClassDumpType innerClassDumpType, Dumper d) {
         d.keyword(getAccessFlagsString(c.getAccessFlags(), dumpableAccessFlagsClass));
 
-        d.keyword("record ").dump(c.getClassType()).print("(");
+        d.keyword("record ");
+        c.dumpClassIdentity(d);
+        d.print("(");
         List<ClassFileField> fields = Functional.filter(c.getFields(), new Predicate<ClassFileField>() {
                     @Override
                     public boolean test(ClassFileField in) {


### PR DESCRIPTION
This method seems to dump type parameters and type annotations in addition. The side effects should not be too bad, I guess...

Closes #268