### PR TITLE
Dump module import statements and annotations

### DIFF
--- a/src/org/benf/cfr/reader/entities/annotations/AnnotationTableEntry.java
+++ b/src/org/benf/cfr/reader/entities/annotations/AnnotationTableEntry.java
@@ -5,6 +5,7 @@ import org.benf.cfr.reader.state.TypeUsageCollector;
 import org.benf.cfr.reader.util.StringUtils;
 import org.benf.cfr.reader.util.TypeUsageCollectable;
 import org.benf.cfr.reader.util.output.Dumper;
+import org.benf.cfr.reader.util.output.ToStringDumper;
 
 import java.util.Map;
 
@@ -58,5 +59,12 @@ public class AnnotationTableEntry implements TypeUsageCollectable {
 
     public boolean isAnnotationEqual(AnnotationTableEntry other) {
         return clazz.equals(other.getClazz()) && elementValueMap.equals(other.elementValueMap);
+    }
+
+    @Override
+    public String toString() {
+        ToStringDumper dumper = new ToStringDumper();
+        dump(dumper);
+        return dumper.toString();
     }
 }

--- a/src/org/benf/cfr/reader/entities/attributes/AttributeAnnotations.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributeAnnotations.java
@@ -74,4 +74,9 @@ public abstract class AttributeAnnotations extends Attribute implements TypeUsag
             annotationTableEntry.collectTypeUsages(collector);
         }
     }
+
+    @Override
+    public String toString() {
+        return annotationTableEntryList.toString();
+    }
 }

--- a/src/org/benf/cfr/reader/entities/attributes/AttributeMap.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributeMap.java
@@ -51,4 +51,9 @@ public class AttributeMap implements TypeUsageCollectable {
         }
         return false;
     }
+
+    @Override
+    public String toString() {
+        return attributes.toString();
+    }
 }

--- a/src/org/benf/cfr/reader/entities/classfilehelpers/ClassFileDumperModule.java
+++ b/src/org/benf/cfr/reader/entities/classfilehelpers/ClassFileDumperModule.java
@@ -23,6 +23,11 @@ public class ClassFileDumperModule extends AbstractClassFileDumper {
 
     @Override
     public Dumper dump(ClassFile classFile, InnerClassDumpType innerClass, Dumper d) {
+        dumpTopHeader(classFile, d, false);
+        dumpImports(d, classFile);
+        dumpComments(classFile, d);
+        dumpAnnotations(classFile, d);
+
         AttributeModule module = classFile.getAttributes().getByName(AttributeModule.ATTRIBUTE_NAME);
         ConstantPool cp = module.getCp();
         Set<AttributeModule.ModuleFlags> flags = module.getFlags();
@@ -108,7 +113,6 @@ public class ClassFileDumperModule extends AbstractClassFileDumper {
             }
             d.endCodeln();
         }
-        d.newln();
     }
 
 

--- a/src/org/benf/cfr/reader/util/output/ToStringDumper.java
+++ b/src/org/benf/cfr/reader/util/output/ToStringDumper.java
@@ -1,6 +1,5 @@
 package org.benf.cfr.reader.util.output;
 
-import org.benf.cfr.reader.bytecode.analysis.loc.HasByteCodeLoc;
 import org.benf.cfr.reader.bytecode.analysis.types.JavaRefTypeInstance;
 import org.benf.cfr.reader.bytecode.analysis.types.JavaTypeInstance;
 import org.benf.cfr.reader.bytecode.analysis.types.MethodPrototype;
@@ -169,6 +168,9 @@ public class ToStringDumper extends AbstractDumper {
         return this;
     }
 
+    /**
+     * Returns the dumped output.
+     */
     @Override
     public String toString() {
         return sb.toString();


### PR DESCRIPTION
Note: This also includes implementing `toString()` for some classes; if you want I can omit that change.

Before:
```java
module test {
    provides List with MyList;

}
```

After:
```
/*
 * Decompiled with CFR 0.153-SNAPSHOT (02dac77).
 * 
 * Could not load the following classes:
 *  test.MyList
 */
import java.util.List;
import test.MyList;

@Deprecated
module test {
    provides List with MyList;
}
```
