### PR TITLE
Module dumping improvements

### DIFF
--- a/src/org/benf/cfr/reader/entities/attributes/AttributeModule.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributeModule.java
@@ -178,6 +178,9 @@ public class AttributeModule extends Attribute {
             return offset;
         }
 
+        public int getIndex() {
+            return index;
+        }
     }
 
     public static class Provide {

--- a/src/org/benf/cfr/reader/entities/attributes/AttributeModule.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributeModule.java
@@ -2,6 +2,7 @@ package org.benf.cfr.reader.entities.attributes;
 
 import org.benf.cfr.reader.entities.constantpool.ConstantPool;
 import org.benf.cfr.reader.entities.constantpool.ConstantPoolEntryModuleInfo;
+import org.benf.cfr.reader.entities.constantpool.ConstantPoolEntryUTF8;
 import org.benf.cfr.reader.util.bytestream.ByteData;
 import org.benf.cfr.reader.util.collections.ListFactory;
 import org.benf.cfr.reader.util.output.Dumper;
@@ -20,7 +21,6 @@ public class AttributeModule extends Attribute {
     private static final long OFFSET_OF_DYNAMIC_INFO = 12;
     private final int nameIdx;
     private final int flags;
-    @SuppressWarnings({"unused", "FieldCanBeLocal"})
     private final int versionIdx;
     private final List<Require> requires;
     private final List<ExportOpen> exports;
@@ -89,15 +89,25 @@ public class AttributeModule extends Attribute {
     public static class Require {
         private final int index;
         private final int flags;
-        @SuppressWarnings("unused")
         private final int version_index;
 
+        /**
+         * Gets the index of the referenced {@link ConstantPoolEntryModuleInfo}.
+         */
         public int getIndex() {
             return index;
         }
 
         public Set<ModuleContentFlags> getFlags() {
             return ModuleContentFlags.build(flags);
+        }
+
+        /**
+         * Gets the index of the referenced {@link ConstantPoolEntryUTF8}, or 0 if no
+         * version information is specified.
+         */
+        public int getVersionIndex() {
+            return version_index;
         }
 
         private Require(int index, int flags, int version_index) {
@@ -290,5 +300,13 @@ public class AttributeModule extends Attribute {
         return ((ConstantPoolEntryModuleInfo)cp.getEntry(nameIdx)).getName().getValue();
     }
 
-
+    /**
+     * Gets the module version, or {@code null} if not specified.
+     */
+    public String getModuleVersion() {
+        if (versionIdx == 0) {
+            return null;
+        }
+        return cp.getUTF8Entry(versionIdx).getValue();
+    }
 }

--- a/src/org/benf/cfr/reader/entities/attributes/AttributeModule.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributeModule.java
@@ -60,7 +60,7 @@ public class AttributeModule extends Attribute {
 
     public enum ModuleContentFlags {
         TRANSITIVE("transitive"),
-        STATIC_PHASE("/* static phase */"),
+        STATIC_PHASE("static"),
         SYNTHETIC("/* synthetic */"),
         MANDATED("/* mandated */");
 

--- a/src/org/benf/cfr/reader/entities/classfilehelpers/ClassFileDumperModule.java
+++ b/src/org/benf/cfr/reader/entities/classfilehelpers/ClassFileDumperModule.java
@@ -37,6 +37,7 @@ public class ClassFileDumperModule extends AbstractClassFileDumper {
         dumpRequires(cp, d, module.getRequires());
         dumpOpensExports(cp, d, module.getExports(), "exports");
         dumpOpensExports(cp, d, module.getOpens(), "opens");
+        dumpUses(cp, d, module.getUses());
         dumpProvides(cp, d, module.getProvides());
         d.indent(-1);
         d.print("}").newln();
@@ -87,6 +88,22 @@ public class ClassFileDumperModule extends AbstractClassFileDumper {
                     d.print(toModule.getName().getValue());
                 }
             }
+            d.endCodeln();
+            effect = true;
+        }
+        if (effect) {
+            d.newln();
+        }
+    }
+
+    private void dumpUses(ConstantPool cp, Dumper d, List<AttributeModule.Use> l) {
+        if (l.isEmpty()) {
+            return;
+        }
+        boolean effect = false;
+        for (AttributeModule.Use u : l) {
+            ConstantPoolEntryClass pck = cp.getClassEntry(u.getIndex());
+            d.print("uses ").dump(pck.getTypeInstance());
             d.endCodeln();
             effect = true;
         }

--- a/src/org/benf/cfr/reader/entities/classfilehelpers/ClassFileDumperModule.java
+++ b/src/org/benf/cfr/reader/entities/classfilehelpers/ClassFileDumperModule.java
@@ -34,6 +34,12 @@ public class ClassFileDumperModule extends AbstractClassFileDumper {
         d.print(CollectionUtils.joinPostFix(flags, " "));
         d.print("module ").print(module.getModuleName()).print(" {").newln();
         d.indent(1);
+        String moduleVersion = module.getModuleVersion();
+        if (moduleVersion != null) {
+            d.comment("version: " + moduleVersion);
+            d.newln();
+        }
+
         dumpRequires(cp, d, module.getRequires());
         dumpOpensExports(cp, d, module.getExports(), "exports");
         dumpOpensExports(cp, d, module.getOpens(), "opens");
@@ -57,7 +63,14 @@ public class ClassFileDumperModule extends AbstractClassFileDumper {
             ConstantPoolEntryModuleInfo module = cp.getModuleEntry(r.getIndex());
             d.print("requires ");
             d.print(CollectionUtils.joinPostFix(flags, " "));
-            d.print(module.getName().getValue()).endCodeln();
+            d.print(module.getName().getValue());
+
+            int versionIndex = r.getVersionIndex();
+            if (versionIndex != 0) {
+                d.print(" /* version: " + cp.getUTF8Entry(versionIndex).getValue() + " */");
+            }
+
+            d.endCodeln();
             effect = true;
         }
         if (effect) {


### PR DESCRIPTION
- Properly dumps `requires static` (instead of including `/* static phase */`)
- Dumps `uses` directives (they were missing before)
- Dumps information about module versions as comments, if present

Example:
```java
module test {
    requires static java.sql;
    
    uses java.util.List;
}
```
Compile with `javac --module-version=99 .\module-info.java`.

Output:
```java
/*
 * Decompiled with CFR 0.153-SNAPSHOT (a260598).
 */
import java.util.List;

open module test {
    // version: 99

    requires static java.sql /* version: 17 */;

    uses List;

}
```