### PR TITLE
Fix `& Serializable` casts being omitted for method reference expressions

### DIFF
--- a/src/org/benf/cfr/reader/bytecode/analysis/opgraph/op4rewriters/LambdaRewriter.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/opgraph/op4rewriters/LambdaRewriter.java
@@ -33,6 +33,7 @@ import org.benf.cfr.reader.bytecode.analysis.structured.statement.StructuredRetu
 import org.benf.cfr.reader.bytecode.analysis.types.DynamicInvokeType;
 import org.benf.cfr.reader.bytecode.analysis.types.GenericTypeBinder;
 import org.benf.cfr.reader.bytecode.analysis.types.JavaGenericRefTypeInstance;
+import org.benf.cfr.reader.bytecode.analysis.types.JavaIntersectionTypeInstance;
 import org.benf.cfr.reader.bytecode.analysis.types.JavaRefTypeInstance;
 import org.benf.cfr.reader.bytecode.analysis.types.JavaTypeInstance;
 import org.benf.cfr.reader.bytecode.analysis.types.MethodPrototype;
@@ -110,14 +111,19 @@ public class LambdaRewriter implements Op04Rewriter, ExpressionRewriter {
                 if (child instanceof LambdaExpressionCommon) {
                     JavaTypeInstance resType = res.getInferredJavaType().getJavaTypeInstance();
                     JavaTypeInstance childType = child.getInferredJavaType().getJavaTypeInstance();
-                    if (childType.implicitlyCastsTo(resType, null)) {
+
+                    // If the child type is an intersection type it cannot be removed safely, at least not if
+                    // it includes Serializable since that makes the complete lambda serializable
+                    if (childType instanceof JavaIntersectionTypeInstance) {
+                        return new CastExpression(BytecodeLoc.NONE, child.getInferredJavaType(), child, true);
+                    } else if (childType.implicitlyCastsTo(resType, null)) {
                         return child;
                     } else {
                         /*
                          * This is more interesting - the cast doesn't work?  This means we might need to explicitly label
                          * the lambda expression type.
                          */
-                        Expression tmp = ((LambdaExpressionCommon) child).childCastForced() ? child : new CastExpression(BytecodeLoc.NONE, child.getInferredJavaType(), child, true);
+                        Expression tmp = new CastExpression(BytecodeLoc.NONE, child.getInferredJavaType(), child, true);
                         res = new CastExpression(BytecodeLoc.NONE, res.getInferredJavaType(), tmp);
                         return res;
                     }

--- a/src/org/benf/cfr/reader/bytecode/analysis/parse/expression/LambdaExpression.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/parse/expression/LambdaExpression.java
@@ -13,7 +13,6 @@ import org.benf.cfr.reader.bytecode.analysis.parse.utils.LValueRewriter;
 import org.benf.cfr.reader.bytecode.analysis.parse.utils.LValueUsageCollector;
 import org.benf.cfr.reader.bytecode.analysis.parse.utils.SSAIdentifiers;
 import org.benf.cfr.reader.bytecode.analysis.parse.utils.scope.LValueScopeDiscoverer;
-import org.benf.cfr.reader.bytecode.analysis.types.JavaIntersectionTypeInstance;
 import org.benf.cfr.reader.bytecode.analysis.types.JavaTypeInstance;
 import org.benf.cfr.reader.bytecode.analysis.types.discovery.InferredJavaType;
 import org.benf.cfr.reader.state.TypeUsageCollector;
@@ -86,11 +85,6 @@ public class LambdaExpression extends AbstractExpression implements LambdaExpres
     }
 
     @Override
-    public boolean childCastForced() {
-        return getInferredJavaType().getJavaTypeInstance() instanceof JavaIntersectionTypeInstance;
-    }
-
-    @Override
     public Precedence getPrecedence() {
         return Precedence.PAREN_SUB_MEMBER;
     }
@@ -99,10 +93,6 @@ public class LambdaExpression extends AbstractExpression implements LambdaExpres
     public Dumper dumpInner(Dumper d) {
         boolean multi = args.size() != 1;
         boolean first = true;
-        // If we need to CAST the lambda to something, we have to do this.
-        if (childCastForced()) {
-            d.separator("(").dump(getInferredJavaType().getJavaTypeInstance()).separator(")");
-        }
         if (explicitArgTypes != null && explicitArgTypes.size() == args.size()) {
             d.separator("(");
             for (int i=0;i<args.size();++i) {

--- a/src/org/benf/cfr/reader/bytecode/analysis/parse/expression/LambdaExpressionCommon.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/parse/expression/LambdaExpressionCommon.java
@@ -1,5 +1,4 @@
 package org.benf.cfr.reader.bytecode.analysis.parse.expression;
 
 public interface LambdaExpressionCommon {
-    boolean childCastForced();
 }

--- a/src/org/benf/cfr/reader/bytecode/analysis/parse/expression/LambdaExpressionFallback.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/parse/expression/LambdaExpressionFallback.java
@@ -93,11 +93,6 @@ public class LambdaExpressionFallback extends AbstractExpression implements Lamb
     }
 
     @Override
-    public boolean childCastForced() {
-        return false;
-    }
-
-    @Override
     public void collectTypeUsages(TypeUsageCollector collector) {
         collector.collect(targetFnArgTypes);
         collector.collectFrom(curriedArgs);

--- a/src/org/benf/cfr/reader/bytecode/analysis/parse/expression/LambdaExpressionNewArray.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/parse/expression/LambdaExpressionNewArray.java
@@ -38,11 +38,6 @@ public class LambdaExpressionNewArray extends AbstractExpression implements Lamb
     }
 
     @Override
-    public boolean childCastForced() {
-        return false;
-    }
-
-    @Override
     public Expression replaceSingleUsageLValues(LValueRewriter lValueRewriter, SSAIdentifiers ssaIdentifiers, StatementContainer statementContainer) {
         return this;
     }


### PR DESCRIPTION
When a lambda or method reference expression is cast with an intersection type consisting of `Serializable` (e.g. `(Runnable & Serializable)`) it makes the lambda or method reference serializable. That cast must therefore not be omitted.

Previously CFR handled this correctly for lambda expressions, but for method references it erroneously omitted the cast. This pull request tries to fix this. I am however not sure if this is the correct approach, maybe there is an underlying bug in how CFR determines whether an intersection type cast may be omitted.

### Example
#### Source code
```java
import java.io.Serializable;
import java.util.function.IntFunction;

class LambdaSerialization {
    private static void doSomething() {}
    private static void doSomethingWithParam(int i) {}
    
    public static void main(String[] args) throws Exception {
        Runnable r;
        r = (Runnable & Serializable) () -> doSomethingWithParam(0);
        r = (Runnable & Serializable) () -> doSomething();
        r = (Runnable & Serializable) LambdaSerialization::doSomething;
        r = (Runnable & Serializable) LambdaSerialization::new;
        
        Object o;
        o = (IntFunction<String[]> & Serializable) String[]::new;
    }
}
```

#### Output
Before (CFR 0.153-SNAPSHOT (c69ed17)):
```java
Runnable runnable = (Runnable & Serializable)() -> LambdaSerialization.doSomethingWithParam(0);
runnable = (Runnable & Serializable)() -> LambdaSerialization.doSomething();
runnable = LambdaSerialization::doSomething;
runnable = LambdaSerialization::new;
IntFunction intFunction = String[]::new;
```

After:
```java
Runnable runnable = (Runnable & Serializable)() -> LambdaSerialization.doSomethingWithParam(0);
runnable = (Runnable & Serializable)() -> LambdaSerialization.doSomething();
runnable = (Runnable & Serializable)LambdaSerialization::doSomething;
runnable = (Runnable & Serializable)LambdaSerialization::new;
IntFunction intFunction = (IntFunction<String[]> & Serializable)(String[]::new);
```
