### PR TITLE
Dump `RECORD_COMPONENT` annotations

### DIFF
--- a/src/org/benf/cfr/reader/bytecode/analysis/opgraph/op4rewriters/RecordRewriter.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/opgraph/op4rewriters/RecordRewriter.java
@@ -301,7 +301,19 @@ public class RecordRewriter {
         ClassFileField cff = getCFF(wcm.getLValueWildCard("var").getMatch(), thisType);
         if (cff != classFileField) return;
         classFileField.markHidden();
-        method.hideDead();
+
+        /*
+         * If method has annotations cannot hide it. This is due to ambiguities regarding whether
+         * method was explicitly declared in source and annotated, or whether it was generated
+         * by the compiler and annotations with target METHOD were propagated from annotated
+         * record component. Class file currently does not contain enough information to determine
+         * this (see https://bugs.openjdk.org/browse/JDK-8251375), so to avoid losing annotations
+         * by accident or introducing unwanted side effects by placing them on record component,
+         * just keep the method.
+         */
+        if (method.getMethodAnnotations().isEmpty()) {
+            method.hideDead();
+        }
     }
 
     private static void hideConstructorIfEmpty(Method canonicalCons) {

--- a/src/org/benf/cfr/reader/entities/Method.java
+++ b/src/org/benf/cfr/reader/entities/Method.java
@@ -26,6 +26,7 @@ import org.benf.cfr.reader.util.*;
 import org.benf.cfr.reader.util.bytestream.ByteData;
 import org.benf.cfr.reader.util.collections.CollectionUtils;
 import org.benf.cfr.reader.util.collections.Functional;
+import org.benf.cfr.reader.util.collections.ListFactory;
 import org.benf.cfr.reader.util.collections.MapFactory;
 import org.benf.cfr.reader.util.collections.SetFactory;
 import org.benf.cfr.reader.util.functors.Predicate;
@@ -443,6 +444,12 @@ public class Method implements KnowsRawSize, TypeUsageCollectable {
             thrownTypes = new LinkedHashSet<JavaTypeInstance>(getDeclaredThrownTypes());
         }
         return thrownTypes;
+    }
+
+    /** Gets the annotations with target {@code METHOD} */
+    public List<AnnotationTableEntry> getMethodAnnotations() {
+        MethodPrototypeAnnotationsHelper annotationsHelper = new MethodPrototypeAnnotationsHelper(attributes);
+        return ListFactory.orEmptyList(annotationsHelper.getMethodAnnotations());
     }
 
     private void dumpSignatureText(boolean asClass, Dumper d) {

--- a/src/org/benf/cfr/reader/entities/attributes/AttributeAnnotations.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributeAnnotations.java
@@ -12,6 +12,7 @@ import org.benf.cfr.reader.util.TypeUsageCollectable;
 import org.benf.cfr.reader.util.bytestream.ByteData;
 import org.benf.cfr.reader.util.output.Dumper;
 
+import java.util.Collections;
 import java.util.List;
 
 public abstract class AttributeAnnotations extends Attribute implements TypeUsageCollectable {
@@ -60,7 +61,8 @@ public abstract class AttributeAnnotations extends Attribute implements TypeUsag
     }
 
     public List<AnnotationTableEntry> getEntryList() {
-        return annotationTableEntryList;
+        // Prevent accidental modification
+        return Collections.unmodifiableList(annotationTableEntryList);
     }
 
     @Override

--- a/src/org/benf/cfr/reader/entities/attributes/AttributeRecord.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributeRecord.java
@@ -1,0 +1,98 @@
+package org.benf.cfr.reader.entities.attributes;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.benf.cfr.reader.entities.constantpool.ConstantPool;
+import org.benf.cfr.reader.entityfactories.AttributeFactory;
+import org.benf.cfr.reader.entityfactories.ContiguousEntityFactory;
+import org.benf.cfr.reader.util.ClassFileVersion;
+import org.benf.cfr.reader.util.bytestream.ByteData;
+import org.benf.cfr.reader.util.collections.ListFactory;
+import org.benf.cfr.reader.util.output.Dumper;
+
+public class AttributeRecord extends Attribute {
+    public static final String ATTRIBUTE_NAME = "Record";
+
+    private static final long OFFSET_OF_ATTRIBUTE_LENGTH = 2;
+    private static final long OFFSET_OF_REMAINDER = 6;
+
+    public static class RecordComponentInfo {
+        private final String name;
+        private final String descriptor;
+        private final List<Attribute> attributes;
+
+        public RecordComponentInfo(String name, String descriptor, List<Attribute> attributes) {
+            this.name = name;
+            this.descriptor = descriptor;
+            this.attributes = attributes;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getDescriptor() {
+            return descriptor;
+        }
+
+        public List<Attribute> getAttributes() {
+            // Prevent accidental modification
+            return Collections.unmodifiableList(attributes);
+        }
+    }
+
+    private final int length;
+    private final List<RecordComponentInfo> componentInfos;
+
+    public AttributeRecord(ByteData raw, ConstantPool cp, ClassFileVersion classFileVersion) {
+        this.length = raw.getS4At(OFFSET_OF_ATTRIBUTE_LENGTH);
+        int numComponents = raw.getU2At(OFFSET_OF_REMAINDER);
+        long offset = OFFSET_OF_REMAINDER + 2;
+
+        componentInfos = ListFactory.newList();
+        for (int i = 0; i < numComponents; i++) {
+            int nameIndex = raw.getS2At(offset);
+            offset += 2;
+            String name = cp.getUTF8Entry(nameIndex).getValue();
+
+            int descriptorIndex = raw.getS2At(offset);
+            offset += 2;
+            String descriptor = cp.getUTF8Entry(descriptorIndex).getValue();
+
+            int attributesCount = raw.getS2At(offset);
+            offset += 2;
+
+            List<Attribute> attributes = ListFactory.newList();
+            raw = raw.getOffsetData(offset);
+            offset = ContiguousEntityFactory.build(raw, attributesCount, attributes,
+                    AttributeFactory.getBuilder(cp, classFileVersion));
+
+            componentInfos.add(new RecordComponentInfo(name, descriptor, attributes));
+        }
+    }
+
+    public List<Attribute> getRecordComponentAttributes(String componentName) {
+        for (RecordComponentInfo componentInfo : componentInfos) {
+            if (componentInfo.getName().equals(componentName)) {
+                return componentInfo.getAttributes();
+            }
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public long getRawByteLength() {
+        return OFFSET_OF_REMAINDER + length;
+    }
+
+    @Override
+    public String getRawName() {
+        return ATTRIBUTE_NAME;
+    }
+
+    @Override
+    public Dumper dump(Dumper d) {
+        return d.print(ATTRIBUTE_NAME);
+    }
+}

--- a/src/org/benf/cfr/reader/entities/attributes/TypeAnnotationEntryValue.java
+++ b/src/org/benf/cfr/reader/entities/attributes/TypeAnnotationEntryValue.java
@@ -11,7 +11,7 @@ public enum TypeAnnotationEntryValue {
     type_extends_implements(0x10, TypeAnnotationEntryKind.supertype_target, TypeAnnotationLocation.ClassFile),
     type_type_parameter_class_interface(0x11, TypeAnnotationEntryKind.type_parameter_bound_target, TypeAnnotationLocation.ClassFile),
     type_type_parameter_method_constructor(0x12, TypeAnnotationEntryKind.type_parameter_bound_target, TypeAnnotationLocation.method_info),
-    type_field(0x13, TypeAnnotationEntryKind.empty_target, TypeAnnotationLocation.field_info),
+    type_field_or_record_component(0x13, TypeAnnotationEntryKind.empty_target, TypeAnnotationLocation.field_info),
     type_ret_or_new(0x14, TypeAnnotationEntryKind.empty_target, TypeAnnotationLocation.method_info),
     type_receiver(0x15, TypeAnnotationEntryKind.empty_target, TypeAnnotationLocation.method_info),
     type_formal(0x16, TypeAnnotationEntryKind.method_formal_parameter_target, TypeAnnotationLocation.method_info),

--- a/src/org/benf/cfr/reader/entityfactories/AttributeFactory.java
+++ b/src/org/benf/cfr/reader/entityfactories/AttributeFactory.java
@@ -77,6 +77,8 @@ public class AttributeFactory {
                 return new AttributeModulePackages(raw);
             } else if (AttributeModuleClassMain.ATTRIBUTE_NAME.equals(attributeName)) {
                 return new AttributeModuleClassMain(raw);
+            } else if (AttributeRecord.ATTRIBUTE_NAME.equals(attributeName)) {
+                return new AttributeRecord(raw, cp, classFileVersion);
             } else if (AttributePermittedSubclasses.ATTRIBUTE_NAME.equals(attributeName)) {
                 return new AttributePermittedSubclasses(raw, cp);
             }

--- a/src/org/benf/cfr/reader/util/collections/Functional.java
+++ b/src/org/benf/cfr/reader/util/collections/Functional.java
@@ -97,6 +97,14 @@ public class Functional {
         return result;
     }
 
+    public static <X, Y> Set<Y> mapToSet(Collection<X> input, UnaryFunction<X, Y> function) {
+        Set<Y> result = SetFactory.newSet();
+        for (X item : input) {
+            result.add(function.invoke(item));
+        }
+        return result;
+    }
+
     public static <X> List<X> uniqAll(List<X> input) {
         Set<X> found = SetFactory.newSet();
         List<X> result = ListFactory.newList();


### PR DESCRIPTION
Fixes #285
Fixes partially #284 (only the case where the method is annotated, but not any other annotation placement)

Feedback or any improvements are appreciated. Maybe this code is also missing logic to properly track the type usage for the annotations.