### PR TITLE
Dump varargs parameter annotations

### DIFF
--- a/src/org/benf/cfr/reader/bytecode/analysis/types/JavaArrayTypeInstance.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/types/JavaArrayTypeInstance.java
@@ -24,7 +24,7 @@ public class JavaArrayTypeInstance implements JavaTypeInstance {
         this.underlyingType = underlyingType;
     }
 
-    private class Annotated implements JavaAnnotatedTypeInstance {
+    class Annotated implements JavaAnnotatedTypeInstance {
         private final List<List<AnnotationTableEntry>> entries;
         private final JavaAnnotatedTypeInstance annotatedUnderlyingType;
 
@@ -36,10 +36,11 @@ public class JavaArrayTypeInstance implements JavaTypeInstance {
             annotatedUnderlyingType = underlyingType.getAnnotatedInstance();
         }
 
-        @Override
-        public Dumper dump(Dumper d) {
+        private Dumper dump(Dumper d, boolean isVarargs) {
             annotatedUnderlyingType.dump(d);
-            for (List<AnnotationTableEntry> entry : entries) {
+            java.util.Iterator<List<AnnotationTableEntry>> entryIterator = entries.iterator();
+            while (entryIterator.hasNext()) {
+                List<AnnotationTableEntry> entry = entryIterator.next();
                 if (!entry.isEmpty()) {
                     d.print(' ');
                     for (AnnotationTableEntry oneEntry : entry) {
@@ -47,9 +48,18 @@ public class JavaArrayTypeInstance implements JavaTypeInstance {
                         d.print(' ');
                     }
                 }
-                d.print("[]");
+                d.print(isVarargs && !entryIterator.hasNext() ? "..." : "[]");
             }
             return d;
+        }
+
+        @Override
+        public Dumper dump(Dumper d) {
+            return dump(d, false);
+        }
+
+        public Dumper dumpVarargs(Dumper d) {
+            return dump(d, true);
         }
 
         @Override

--- a/src/org/benf/cfr/reader/bytecode/analysis/types/MethodPrototype.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/types/MethodPrototype.java
@@ -269,7 +269,7 @@ public class MethodPrototype implements TypeUsageCollectable {
                     annotationsHelper.dumpParamType(arg, paramIdx, d);
                     d.dump(arg);
                 } else {
-                    ((JavaArrayTypeInstance) arg).toVarargString(d);
+                    annotationsHelper.dumpVarargsParamType((JavaArrayTypeInstance) arg, paramIdx, d);
                 }
             } else {
                 annotationsHelper.dumpParamType(arg, paramIdx, d);

--- a/src/org/benf/cfr/reader/bytecode/analysis/types/MethodPrototypeAnnotationsHelper.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/types/MethodPrototypeAnnotationsHelper.java
@@ -80,7 +80,15 @@ public class MethodPrototypeAnnotationsHelper {
         return typeEntries;
     }
 
-    void dumpParamType(JavaTypeInstance arg, final int paramIdx, Dumper d) {
+    void dumpParamType(JavaTypeInstance arg, int paramIdx, Dumper d) {
+        dumpParamType(arg, paramIdx, false, d);
+    }
+
+    void dumpVarargsParamType(JavaArrayTypeInstance arg, int paramIdx, Dumper d) {
+        dumpParamType(arg, paramIdx, true, d);
+    }
+
+    private void dumpParamType(JavaTypeInstance arg, final int paramIdx, boolean isVarargs, Dumper d) {
         List<AnnotationTableEntry> entries = getParameterAnnotations(paramIdx);
         List<AnnotationTableTypeEntry> typeEntries = getTypeParameterAnnotations(paramIdx);
         DeclarationAnnotationsInfo annotationsInfo = DeclarationAnnotationHelper.getDeclarationInfo(arg, entries, typeEntries);
@@ -96,13 +104,22 @@ public class MethodPrototypeAnnotationsHelper {
         dumpAnnotationTableEntries(declAnnotationsToDump, d);
 
         if (typeAnnotationsToDump.isEmpty()) {
-            d.dump(arg);
+            if (isVarargs) {
+                ((JavaArrayTypeInstance) arg).toVarargString(d);
+            } else {
+                d.dump(arg);
+            }
         } else {
             JavaAnnotatedTypeInstance jat = arg.getAnnotatedInstance();
             DecompilerComments comments = new DecompilerComments();
             TypeAnnotationHelper.apply(jat, typeAnnotationsToDump, comments);
             d.dump(comments);
-            d.dump(jat);
+
+            if (isVarargs) {
+                ((JavaArrayTypeInstance.Annotated) jat).dumpVarargs(d);
+            } else {
+                d.dump(jat);
+            }
         }
     }
 }


### PR DESCRIPTION
Previously no varargs parameter annotations were dumped. This can be seen with the following test source (feel free to add it to the tests):
```java
import static java.lang.annotation.RetentionPolicy.RUNTIME;

import java.lang.annotation.ElementType;
import java.lang.annotation.Retention;
import java.lang.annotation.Target;

class VarargsAnnotationTest {
    @Retention(RUNTIME)
    @Target(ElementType.PARAMETER)
    @interface Parameter { }
    
    @Retention(RUNTIME)
    @Target(ElementType.TYPE_USE)
    @interface TypeUse {
        int value();
    }
    
    void varargs1(@Parameter @TypeUse(1) String ... a) {}
    void varargs2(@Parameter String @TypeUse(2) ... a) {}
    void varargs3(@Parameter @TypeUse(1) String @TypeUse(2) ... a) {}
    
    void varargsArray(@Parameter @TypeUse(1) String @TypeUse(2) [] @TypeUse(3) ... a) {}
    
    void array(@Parameter @TypeUse(1) String @TypeUse(2) [] a) {}
    
    void varargsParam(@Parameter String... a) {}
    
    void arrayParam(@Parameter String[] a) {}
}
```