### PR TITLE
bug fix: Occasionally StackOverflow when multiple tasks concurrently decompile one jar file

### DIFF
--- a/src/org/benf/cfr/reader/bytecode/analysis/types/discovery/InferredJavaType.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/types/discovery/InferredJavaType.java
@@ -559,7 +559,8 @@ public class InferredJavaType {
 
         public void mkDelegate(IJTInternal newDelegate) {
             if (isDelegate) {
-                delegate.mkDelegate(newDelegate);
+//                delegate.mkDelegate(newDelegate);
+                InferredJavaType.mkDelegate(delegate, newDelegate);
             } else {
                 isDelegate = true;
                 delegate = newDelegate;


### PR DESCRIPTION
example
```java
package org.benf.cfr.test;

import org.benf.cfr.reader.api.CfrDriver;
import org.junit.jupiter.api.Test;

import java.util.Collections;
import java.util.concurrent.CountDownLatch;

public class ParallelTest {
    CountDownLatch latch = new CountDownLatch(8);
    @Test
    public void parallelTest() throws Exception {
        for (int i = 0; i < 4; ++i) {
            spawnThread("org/inksnow/qreplace/N");
            spawnThread("org/inksnow/qreplace/B");
        }
        latch.await();
    }
    private void spawnThread(String className) {
        new Thread(() -> {
            CfrDriver driver = new CfrDriver.Builder().build();
            driver.analyse(Collections.singletonList("E:\\tmp\\QReplace-1.0.jar"));
            latch.countDown();
        }).start();
    }
}
```
On my machine, this piece of code almost 100% triggers a StackOverflowError.

`QReplace-1.0.jar` is a bukkit plugin developed by my friend @InkerBot .
I have obtained his permission to upload the JAR file here.

[QReplace-1.0.zip](https://github.com/user-attachments/files/25456765/QReplace-1.0.zip)


<details>

<img width="1016" height="538" alt="image" src="https://github.com/user-attachments/assets/573bf0ca-b720-4332-acfb-631e6271ff11" />

</details>
