### PR TITLE
Fix exception when lambda rewriter encounters anonymous array

### DIFF
--- a/src/org/benf/cfr/reader/bytecode/analysis/opgraph/op4rewriters/LambdaRewriter.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/opgraph/op4rewriters/LambdaRewriter.java
@@ -18,6 +18,7 @@ import org.benf.cfr.reader.bytecode.analysis.parse.expression.LambdaExpressionCo
 import org.benf.cfr.reader.bytecode.analysis.parse.expression.LambdaExpressionFallback;
 import org.benf.cfr.reader.bytecode.analysis.parse.expression.LambdaExpressionNewArray;
 import org.benf.cfr.reader.bytecode.analysis.parse.expression.MemberFunctionInvokation;
+import org.benf.cfr.reader.bytecode.analysis.parse.expression.NewAnonymousArray;
 import org.benf.cfr.reader.bytecode.analysis.parse.expression.NewObjectArray;
 import org.benf.cfr.reader.bytecode.analysis.parse.expression.StaticFunctionInvokation;
 import org.benf.cfr.reader.bytecode.analysis.parse.lvalue.LocalVariable;
@@ -458,6 +459,7 @@ public class LambdaRewriter implements Op04Rewriter, ExpressionRewriter {
         if (anonymousLambdaArgs.size() != 1) return false;
 
         if (!(e instanceof AbstractNewArray)) return false;
+        if (e instanceof NewAnonymousArray) return false;
         AbstractNewArray ana = (AbstractNewArray)e;
         if (ana.getNumDims() != 1) return false;
         return ana.getDimSize(0).equals(new LValueExpression(anonymousLambdaArgs.get(0)));


### PR DESCRIPTION
For example something like:
```java
IntFunction<String[]> f = i -> new String[] {"a" + i}
```

Previously caused an `UnsupportedOperationException` in `NewAnonymousArray#getDimSize`.


Note that the FabricMC project tried to fix that already in their fork at https://github.com/FabricMC/cfr/commit/bf71d18c04887dab54584ef062f870a389a7d521. But returning `true` seems incorrect; that would turn the above lambda erroneously into `String[]::new`.