### PR TITLE
Fix wrong module attribute length

### DIFF
--- a/src/org/benf/cfr/reader/entities/attributes/AttributeModule.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributeModule.java
@@ -264,7 +264,7 @@ public class AttributeModule extends Attribute {
 
     @Override
     public long getRawByteLength() {
-        return OFFSET_OF_MODULE_FLAGS + length;
+        return OFFSET_OF_MODULE_NAME + length;
     }
 
     @Override


### PR DESCRIPTION
Fixes #335

The issue was probably not noticeable normally because often there is no subsequent attribute after the `Module` one. However, for the `module-info.class` provided in that issue, there was a subsequent attribute, and the incorrect length caused the read position to be incorrect.

Side note: In general it might be good to refactor and simplify the attribute reading logic? It seems the [structure is always the same](https://docs.oracle.com/javase/specs/jvms/se25/html/jvms-4.html#jvms-4.7); the length is not something specific to a certain attribute. So it might be better to move that outside the attribute reading and remove the overridden `getRawByteLength` method from all attribute classes.
It seems all other attribute implementations return the correct `6 + length`, but this code repetition is rather error-prone.