### PR TITLE
Fix generic type clash not being detected

### DIFF
--- a/src/org/benf/cfr/reader/bytecode/analysis/types/discovery/InferredJavaType.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/types/discovery/InferredJavaType.java
@@ -149,7 +149,22 @@ public class InferredJavaType {
                     continue;
                 }
                 Map<? extends JavaTypeInstance, JavaGenericRefTypeInstance> boundSupers = otherSupers.getBoundSuperClasses();
-                matches.keySet().retainAll(boundSupers.keySet());
+
+                Iterator<Map.Entry<JavaTypeInstance, JavaGenericRefTypeInstance>> matchesIter = matches.entrySet().iterator();
+                while (matchesIter.hasNext()) {
+                    Map.Entry<JavaTypeInstance, JavaGenericRefTypeInstance> entry = matchesIter.next();
+                    if (!boundSupers.containsKey(entry.getKey())) {
+                        matchesIter.remove();
+                    } else {
+                        JavaGenericRefTypeInstance matchGeneric = entry.getValue();
+                        JavaGenericRefTypeInstance otherGeneric = boundSupers.get(entry.getKey());
+
+                        if (!MiscUtils.objectsEquals(matchGeneric, otherGeneric)) {
+                            // TODO: Try to determine common generic supertype?
+                            matchesIter.remove();
+                        }
+                    }
+                }
             }
             return matches;
         }

--- a/src/org/benf/cfr/reader/util/MiscUtils.java
+++ b/src/org/benf/cfr/reader/util/MiscUtils.java
@@ -5,6 +5,7 @@ import org.benf.cfr.reader.bytecode.analysis.parse.LValue;
 import org.benf.cfr.reader.bytecode.analysis.parse.expression.LValueExpression;
 import org.benf.cfr.reader.bytecode.analysis.parse.lvalue.LocalVariable;
 import org.benf.cfr.reader.bytecode.analysis.types.JavaTypeInstance;
+import org.benf.cfr.reader.util.annotation.Nullable;
 import org.benf.cfr.reader.util.functors.Predicate;
 
 import java.util.regex.Pattern;
@@ -46,6 +47,10 @@ public class MiscUtils {
      * up by letting code analysers say we're no good kids, hanging around wasting time.
      */
     public static void handyBreakPoint() {
+    }
+
+    public static boolean objectsEquals(@Nullable Object o1, @Nullable Object o2) {
+        return o1 == o2 || o1 != null && o1.equals(o2);
     }
 
     public static boolean isThis(Expression obj, JavaTypeInstance thisType) {


### PR DESCRIPTION
Fixes #350

The problem was that the code previously only considered the raw supertype but did not check for parameterized type incompatibilities.

Note: This might lead to worse decompilation results which need more casts, but the results should be more correct (?).