### PR TITLE
Remove redundant null check for `instanceof` patterns

### DIFF
--- a/src/org/benf/cfr/reader/bytecode/analysis/opgraph/op3rewriters/CondenseConditionals.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/opgraph/op3rewriters/CondenseConditionals.java
@@ -538,6 +538,20 @@ public class CondenseConditionals {
         return effect;
     }
 
+    /**
+     * Returns whether {@code cond} is a redundant null-check for the known non-null {@code nonNullVar}.
+     *
+     * <p>This only covers the artificially introduced null-check added by {@link #condenseInstanceOfAssign}.
+     */
+    public static boolean isRedundantInstanceOfNullCheck(ConditionalExpression cond, LValue nonNullVar) {
+        if (cond instanceof ComparisonOperation) {
+            ComparisonOperation comp = (ComparisonOperation) cond;
+            return comp.getOp() == CompOp.NE && comp.getLhs().equals(Literal.NULL)
+                    && (comp.getRhs() instanceof LValueExpression) && ((LValueExpression) comp.getRhs()).getLValue().equals(nonNullVar);
+        }
+        return false;
+    }
+
     /*
      * Return the InstanceOfExpression if the condition is SOLELY a negated instanceof,
      * i.e.  !(o instanceof T)  or  (o instanceof T) == false.

--- a/src/org/benf/cfr/reader/bytecode/analysis/opgraph/op4rewriters/transformers/InstanceOfAssignRewriter.java
+++ b/src/org/benf/cfr/reader/bytecode/analysis/opgraph/op4rewriters/transformers/InstanceOfAssignRewriter.java
@@ -1,6 +1,7 @@
 package org.benf.cfr.reader.bytecode.analysis.opgraph.op4rewriters.transformers;
 
 import org.benf.cfr.reader.bytecode.analysis.loc.BytecodeLoc;
+import org.benf.cfr.reader.bytecode.analysis.opgraph.op3rewriters.CondenseConditionals;
 import org.benf.cfr.reader.bytecode.analysis.opgraph.op4rewriters.ExpressionReplacingRewriter;
 import org.benf.cfr.reader.bytecode.analysis.parse.Expression;
 import org.benf.cfr.reader.bytecode.analysis.parse.LValue;
@@ -228,7 +229,13 @@ public class InstanceOfAssignRewriter {
                     scopedEntity
             ));
             ConditionalExpression newRhs = new ExpressionReplacingRewriter(originalAssign, new LValueExpression(scopedEntity)).rewriteExpression(bo.getRhs(), null, null, null);
-            ce = new BooleanOperation(BytecodeLoc.NONE, newLhs, newRhs, bo.getOp());
+            // `scopedEntity` is assigned by instanceof and is therefore known to be non-null
+            if (CondenseConditionals.isRedundantInstanceOfNullCheck(newRhs, scopedEntity)) {
+                // Ignore the redundant newRhs
+                ce = newLhs;
+            } else {
+                ce = new BooleanOperation(BytecodeLoc.NONE, newLhs, newRhs, bo.getOp());
+            }
         }
         if (!ct.isPositive) {
             ce = ce.getNegated();


### PR DESCRIPTION
`CondenseConditionals#condenseInstanceOfAssign` introduces a redundant null-check (apparently to lift the assignment into the `if` condition?) which ends up in the decompiled output:
https://github.com/leibnitz27/cfr/blob/a0d8fbfd4ef24ddbc4f54db500267a44f0b56307/src/org/benf/cfr/reader/bytecode/analysis/opgraph/op3rewriters/CondenseConditionals.java#L506-L509

This PR here tries to detect that and remove it again.

Example (JDK 21):
```java
class InstanceOfTest {
    int m(Object o1, Object o2) {
        if (o1 instanceof String s1 && o2 instanceof String s2) {
            return s1.compareTo(s2);
        }
        return 0;
    }
}
```

Decompiled:
```diff
- if (object instanceof String var3_3 && null != var3_3 && object2 instanceof String) {
+ if (object instanceof String var3_3 && object2 instanceof String) {
```