### PR TITLE
Simplify reading of attributes

### DIFF
--- a/src/org/benf/cfr/reader/entities/ClassFile.java
+++ b/src/org/benf/cfr/reader/entities/ClassFile.java
@@ -224,11 +224,7 @@ public class ClassFile implements Dumpable, TypeUsageCollectable {
         final long OFFSET_OF_ATTRIBUTES_COUNT = OFFSET_OF_METHODS + methodsLength;
         final long OFFSET_OF_ATTRIBUTES = OFFSET_OF_ATTRIBUTES_COUNT + 2;
         final int numAttributes = data.getU2At(OFFSET_OF_ATTRIBUTES_COUNT);
-        ArrayList<Attribute> tmpAttributes = new ArrayList<Attribute>();
-        tmpAttributes.ensureCapacity(numAttributes);
-        ContiguousEntityFactory.build(data.getOffsetData(OFFSET_OF_ATTRIBUTES), numAttributes, tmpAttributes,
-                AttributeFactory.getBuilder(constantPool, classFileVersion)
-        );
+        List<Attribute> tmpAttributes = AttributeFactory.readAttributes(data.getOffsetData(OFFSET_OF_ATTRIBUTES), constantPool, classFileVersion, numAttributes);
 
         this.attributes = new AttributeMap(tmpAttributes);
         AccessFlag.applyAttributes(attributes, accessFlags);

--- a/src/org/benf/cfr/reader/entities/Field.java
+++ b/src/org/benf/cfr/reader/entities/Field.java
@@ -18,7 +18,6 @@ import org.benf.cfr.reader.entities.constantpool.ConstantPool;
 import org.benf.cfr.reader.entities.constantpool.ConstantPoolEntryUTF8;
 import org.benf.cfr.reader.entities.constantpool.ConstantPoolUtils;
 import org.benf.cfr.reader.entityfactories.AttributeFactory;
-import org.benf.cfr.reader.entityfactories.ContiguousEntityFactory;
 import org.benf.cfr.reader.state.TypeUsageCollector;
 import org.benf.cfr.reader.util.ClassFileVersion;
 import org.benf.cfr.reader.util.DecompilerComments;
@@ -63,10 +62,8 @@ public class Field implements KnowsRawSize, TypeUsageCollectable {
         this.cp = cp;
         this.accessFlags = AccessFlag.build(raw.getU2At(OFFSET_OF_ACCESS_FLAGS));
         int attributes_count = raw.getU2At(OFFSET_OF_ATTRIBUTES_COUNT);
-        ArrayList<Attribute> tmpAttributes = new ArrayList<Attribute>();
-        tmpAttributes.ensureCapacity(attributes_count);
-        long attributesLength = ContiguousEntityFactory.build(raw.getOffsetData(OFFSET_OF_ATTRIBUTES), attributes_count, tmpAttributes,
-                AttributeFactory.getBuilder(cp, classFileVersion));
+        ArrayList<Attribute> tmpAttributes = new ArrayList<Attribute>(attributes_count);
+        long attributesLength = AttributeFactory.readAttributes(raw.getOffsetData(OFFSET_OF_ATTRIBUTES), cp, classFileVersion, attributes_count, tmpAttributes);
 
         this.attributes = new AttributeMap(tmpAttributes);
         AccessFlag.applyAttributes(attributes, accessFlags);

--- a/src/org/benf/cfr/reader/entities/Method.java
+++ b/src/org/benf/cfr/reader/entities/Method.java
@@ -17,7 +17,6 @@ import org.benf.cfr.reader.entities.constantpool.ConstantPoolEntryClass;
 import org.benf.cfr.reader.entities.constantpool.ConstantPoolEntryUTF8;
 import org.benf.cfr.reader.entities.constantpool.ConstantPoolUtils;
 import org.benf.cfr.reader.entityfactories.AttributeFactory;
-import org.benf.cfr.reader.entityfactories.ContiguousEntityFactory;
 import org.benf.cfr.reader.state.DCCommonState;
 import org.benf.cfr.reader.state.LocalClassAwareTypeUsageInformation;
 import org.benf.cfr.reader.state.TypeUsageCollector;
@@ -114,10 +113,8 @@ public class Method implements KnowsRawSize, TypeUsageCollectable {
         String initialName = cp.getUTF8Entry(nameIndex).getValue();
 
         int numAttributes = raw.getU2At(OFFSET_OF_ATTRIBUTES_COUNT);
-        ArrayList<Attribute> tmpAttributes = new ArrayList<Attribute>();
-        tmpAttributes.ensureCapacity(numAttributes);
-        long attributesLength = ContiguousEntityFactory.build(raw.getOffsetData(OFFSET_OF_ATTRIBUTES), numAttributes, tmpAttributes,
-                AttributeFactory.getBuilder(cp, classFileVersion));
+        ArrayList<Attribute> tmpAttributes = new ArrayList<Attribute>(numAttributes);
+        long attributesLength = AttributeFactory.readAttributes(raw.getOffsetData(OFFSET_OF_ATTRIBUTES), cp, classFileVersion, numAttributes, tmpAttributes);
 
         this.attributes = new AttributeMap(tmpAttributes);
         AccessFlagMethod.applyAttributes(attributes, accessFlags);

--- a/src/org/benf/cfr/reader/entities/attributes/Attribute.java
+++ b/src/org/benf/cfr/reader/entities/attributes/Attribute.java
@@ -2,12 +2,11 @@ package org.benf.cfr.reader.entities.attributes;
 
 import org.benf.cfr.reader.state.TypeUsageCollector;
 import org.benf.cfr.reader.util.KnowsRawName;
-import org.benf.cfr.reader.util.KnowsRawSize;
 import org.benf.cfr.reader.util.TypeUsageCollectable;
 import org.benf.cfr.reader.util.output.Dumpable;
 import org.benf.cfr.reader.util.output.Dumper;
 
-public abstract class Attribute implements KnowsRawSize, KnowsRawName, Dumpable, TypeUsageCollectable {
+public abstract class Attribute implements KnowsRawName, Dumpable, TypeUsageCollectable {
 
     @Override
     public abstract Dumper dump(Dumper d);

--- a/src/org/benf/cfr/reader/entities/attributes/AttributeAnnotationDefault.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributeAnnotationDefault.java
@@ -10,15 +10,10 @@ import org.benf.cfr.reader.util.output.Dumper;
 public class AttributeAnnotationDefault extends Attribute {
     public static final String ATTRIBUTE_NAME = "AnnotationDefault";
 
-    private static final long OFFSET_OF_ATTRIBUTE_LENGTH = 2;
-    private static final long OFFSET_OF_REMAINDER = 6;
-
-    private final int length;
     private final ElementValue elementValue;
 
     public AttributeAnnotationDefault(ByteData raw, ConstantPool cp) {
-        this.length = raw.getS4At(OFFSET_OF_ATTRIBUTE_LENGTH);
-        Pair<Long, ElementValue> tmp = AnnotationHelpers.getElementValue(raw, OFFSET_OF_REMAINDER, cp);
+        Pair<Long, ElementValue> tmp = AnnotationHelpers.getElementValue(raw, 0, cp);
         this.elementValue = tmp.getSecond();
     }
 
@@ -30,11 +25,6 @@ public class AttributeAnnotationDefault extends Attribute {
     @Override
     public Dumper dump(Dumper d) {
         return elementValue.dump(d);
-    }
-
-    @Override
-    public long getRawByteLength() {
-        return OFFSET_OF_REMAINDER + length;
     }
 
     @Override

--- a/src/org/benf/cfr/reader/entities/attributes/AttributeAnnotations.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributeAnnotations.java
@@ -17,17 +17,12 @@ import java.util.List;
 
 public abstract class AttributeAnnotations extends Attribute implements TypeUsageCollectable {
 
-    private static final long OFFSET_OF_ATTRIBUTE_LENGTH = 2;
-    private static final long OFFSET_OF_REMAINDER = 6;
-    private static final long OFFSET_OF_NUMBER_OF_ANNOTATIONS = 6;
-    private static final long OFFSET_OF_ANNOTATION_TABLE = 8;
+    private static final long OFFSET_OF_NUMBER_OF_ANNOTATIONS = 0;
+    private static final long OFFSET_OF_ANNOTATION_TABLE = 2;
 
     private final List<AnnotationTableEntry> annotationTableEntryList = ListFactory.newList();
 
-    private final int length;
-
     AttributeAnnotations(ByteData raw, ConstantPool cp) {
-        this.length = raw.getS4At(OFFSET_OF_ATTRIBUTE_LENGTH);
         int numAnnotations = raw.getU2At(OFFSET_OF_NUMBER_OF_ANNOTATIONS);
         long offset = OFFSET_OF_ANNOTATION_TABLE;
         for (int x = 0; x < numAnnotations; ++x) {
@@ -63,11 +58,6 @@ public abstract class AttributeAnnotations extends Attribute implements TypeUsag
     public List<AnnotationTableEntry> getEntryList() {
         // Prevent accidental modification
         return Collections.unmodifiableList(annotationTableEntryList);
-    }
-
-    @Override
-    public long getRawByteLength() {
-        return OFFSET_OF_REMAINDER + length;
     }
 
     @Override

--- a/src/org/benf/cfr/reader/entities/attributes/AttributeBootstrapMethods.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributeBootstrapMethods.java
@@ -13,16 +13,9 @@ import java.util.List;
 public class AttributeBootstrapMethods extends Attribute {
     public static final String ATTRIBUTE_NAME = "BootstrapMethods";
 
-    private static final long OFFSET_OF_ATTRIBUTE_LENGTH = 2;
-    private static final long OFFSET_OF_REMAINDER = 6;
-
-    private static final long OFFSET_OF_NUM_METHODS = 6;
-
-    private final int length;
     private final List<BootstrapMethodInfo> methodInfoList;
 
     public AttributeBootstrapMethods(ByteData raw, ConstantPool cp) {
-        this.length = raw.getS4At(OFFSET_OF_ATTRIBUTE_LENGTH);
         this.methodInfoList = decodeMethods(raw, cp);
     }
 
@@ -36,8 +29,8 @@ public class AttributeBootstrapMethods extends Attribute {
     private static List<BootstrapMethodInfo> decodeMethods(ByteData raw, ConstantPool cp) {
 
         List<BootstrapMethodInfo> res = ListFactory.newList();
-        int numMethods = raw.getU2At(OFFSET_OF_NUM_METHODS);
-        long offset = OFFSET_OF_NUM_METHODS + 2;
+        int numMethods = raw.getU2At(0);
+        long offset = 2;
         for (int x = 0; x < numMethods; ++x) {
             int methodRef = raw.getU2At(offset);
             ConstantPoolEntryMethodHandle methodHandle = cp.getMethodHandleEntry(methodRef);
@@ -63,11 +56,6 @@ public class AttributeBootstrapMethods extends Attribute {
     @Override
     public Dumper dump(Dumper d) {
         return d.print(ATTRIBUTE_NAME);
-    }
-
-    @Override
-    public long getRawByteLength() {
-        return OFFSET_OF_REMAINDER + length;
     }
 
     @Override

--- a/src/org/benf/cfr/reader/entities/attributes/AttributeCode.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributeCode.java
@@ -18,10 +18,8 @@ import java.util.List;
 public class AttributeCode extends Attribute {
     public static final String ATTRIBUTE_NAME = "Code";
 
-    private static final long OFFSET_OF_ATTRIBUTE_LENGTH = 2;
-    private static final long OFFSET_OF_MAX_STACK = 6;
+    private static final long OFFSET_OF_MAX_STACK = 0;
 
-    private final int length;
     @SuppressWarnings({"FieldCanBeLocal", "unused"})
     private final int maxStack;
     private final int maxLocals;
@@ -35,19 +33,18 @@ public class AttributeCode extends Attribute {
 
     public AttributeCode(ByteData raw, final ConstantPool cp, ClassFileVersion classFileVersion) {
         this.cp = cp;
-        this.length = raw.getS4At(OFFSET_OF_ATTRIBUTE_LENGTH);
 
-        long OFFSET_OF_MAX_LOCALS = 8;
-        long OFFSET_OF_CODE_LENGTH = 10;
-        long OFFSET_OF_CODE = 14;
+        long OFFSET_OF_MAX_LOCALS = 2;
+        long OFFSET_OF_CODE_LENGTH = 4;
+        long OFFSET_OF_CODE = 8;
 
         int maxStack;
         int maxLocals;
         int codeLength;
         if (classFileVersion.before(ClassFileVersion.JAVA_1_0)) {
-            OFFSET_OF_MAX_LOCALS = 7;
-            OFFSET_OF_CODE_LENGTH = 8;
-            OFFSET_OF_CODE = 10;
+            OFFSET_OF_MAX_LOCALS = 1;
+            OFFSET_OF_CODE_LENGTH = 2;
+            OFFSET_OF_CODE = 4;
 
             maxStack = raw.getU1At(OFFSET_OF_MAX_STACK);
             maxLocals = raw.getU1At(OFFSET_OF_MAX_LOCALS);
@@ -76,10 +73,7 @@ public class AttributeCode extends Attribute {
         final long OFFSET_OF_ATTRIBUTES_COUNT = OFFSET_OF_EXCEPTION_TABLE + numBytesExceptionInfo;
         final long OFFSET_OF_ATTRIBUTES = OFFSET_OF_ATTRIBUTES_COUNT + 2;
         final int numAttributes = raw.getU2At(OFFSET_OF_ATTRIBUTES_COUNT);
-        ArrayList<Attribute> tmpAttributes = new ArrayList<Attribute>();
-        tmpAttributes.ensureCapacity(numAttributes);
-        ContiguousEntityFactory.build(raw.getOffsetData(OFFSET_OF_ATTRIBUTES), numAttributes, tmpAttributes,
-                AttributeFactory.getBuilder(cp, classFileVersion));
+        List<Attribute> tmpAttributes = AttributeFactory.readAttributes(raw.getOffsetData(OFFSET_OF_ATTRIBUTES), cp, classFileVersion, numAttributes);
         this.attributes = new AttributeMap(tmpAttributes);
 
         this.rawData = raw.getOffsetData(OFFSET_OF_CODE);
@@ -133,11 +127,6 @@ public class AttributeCode extends Attribute {
     @Override
     public Dumper dump(Dumper d) {
         return codeAnalyser.getAnalysis(getConstantPool().getDCCommonState()).dump(d);
-    }
-
-    @Override
-    public long getRawByteLength() {
-        return OFFSET_OF_MAX_STACK + length;
     }
 
     @Override

--- a/src/org/benf/cfr/reader/entities/attributes/AttributeCode.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributeCode.java
@@ -9,6 +9,7 @@ import org.benf.cfr.reader.entityfactories.AttributeFactory;
 import org.benf.cfr.reader.entityfactories.ContiguousEntityFactory;
 import org.benf.cfr.reader.state.TypeUsageCollector;
 import org.benf.cfr.reader.util.ClassFileVersion;
+import org.benf.cfr.reader.util.ConfusedCFRException;
 import org.benf.cfr.reader.util.bytestream.ByteData;
 import org.benf.cfr.reader.util.output.Dumper;
 
@@ -53,7 +54,12 @@ public class AttributeCode extends Attribute {
         } else {
             maxStack = raw.getU2At(OFFSET_OF_MAX_STACK);
             maxLocals = raw.getU2At(OFFSET_OF_MAX_LOCALS);
-            codeLength = raw.getS4At(OFFSET_OF_CODE_LENGTH);
+            long codeLengthL = raw.getU4At(OFFSET_OF_CODE_LENGTH);
+            // JVM spec actually says this value must be < 65536 (despite it being of type u4), see https://docs.oracle.com/javase/specs/jvms/se25/html/jvms-4.html#jvms-4.7.3
+            if (codeLengthL > Integer.MAX_VALUE) {
+                throw new ConfusedCFRException("Unsupported code length: " + codeLengthL);
+            }
+            codeLength = (int) codeLengthL;
         }
         this.maxStack = maxStack;
         this.maxLocals = maxLocals;

--- a/src/org/benf/cfr/reader/entities/attributes/AttributeConstantValue.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributeConstantValue.java
@@ -8,15 +8,10 @@ import org.benf.cfr.reader.util.output.Dumper;
 public class AttributeConstantValue extends Attribute {
     public static final String ATTRIBUTE_NAME = "ConstantValue";
 
-    private static final long OFFSET_OF_ATTRIBUTE_LENGTH = 2;
-    private static final long OFFSET_OF_REMAINDER = 6;
-
-    private final int length;
     private final ConstantPoolEntry value;
 
     public AttributeConstantValue(ByteData raw, ConstantPool cp) {
-        this.length = raw.getS4At(OFFSET_OF_ATTRIBUTE_LENGTH);
-        this.value = cp.getEntry(raw.getU2At(OFFSET_OF_REMAINDER));
+        this.value = cp.getEntry(raw.getU2At(0));
     }
 
     @Override
@@ -27,11 +22,6 @@ public class AttributeConstantValue extends Attribute {
     @Override
     public Dumper dump(Dumper d) {
         return d.print("ConstantValue : " + value);
-    }
-
-    @Override
-    public long getRawByteLength() {
-        return OFFSET_OF_REMAINDER + length;
     }
 
     @Override

--- a/src/org/benf/cfr/reader/entities/attributes/AttributeDeprecated.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributeDeprecated.java
@@ -1,18 +1,11 @@
 package org.benf.cfr.reader.entities.attributes;
 
-import org.benf.cfr.reader.util.bytestream.ByteData;
 import org.benf.cfr.reader.util.output.Dumper;
 
 public class AttributeDeprecated extends Attribute {
     public static final String ATTRIBUTE_NAME = "Deprecated";
 
-    private static final long OFFSET_OF_ATTRIBUTE_LENGTH = 2;
-    private static final long OFFSET_OF_REMAINDER = 6;
-
-    private final int length;
-
-    public AttributeDeprecated(ByteData raw) {
-        this.length = raw.getS4At(OFFSET_OF_ATTRIBUTE_LENGTH);
+    public AttributeDeprecated() {
     }
 
     @Override
@@ -23,11 +16,6 @@ public class AttributeDeprecated extends Attribute {
     @Override
     public Dumper dump(Dumper d) {
         return d.print("Deprecated");
-    }
-
-    @Override
-    public long getRawByteLength() {
-        return OFFSET_OF_REMAINDER + length;
     }
 
     @Override

--- a/src/org/benf/cfr/reader/entities/attributes/AttributeEnclosingMethod.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributeEnclosingMethod.java
@@ -6,18 +6,12 @@ import org.benf.cfr.reader.util.output.Dumper;
 public class AttributeEnclosingMethod extends Attribute {
     public static final String ATTRIBUTE_NAME = "EnclosingMethod";
 
-    private static final long OFFSET_OF_ATTRIBUTE_LENGTH = 2;
-    private static final long OFFSET_OF_REMAINDER = 6;
-
-    private final int length;
-
     private final int classIndex;
     private final int methodIndex;
 
     public AttributeEnclosingMethod(ByteData raw) {
-        this.length = raw.getS4At(OFFSET_OF_ATTRIBUTE_LENGTH);
-        this.classIndex = raw.getU2At(OFFSET_OF_REMAINDER);
-        this.methodIndex = raw.getU2At(OFFSET_OF_REMAINDER + 2);
+        this.classIndex = raw.getU2At(0);
+        this.methodIndex = raw.getU2At(2);
     }
 
     @Override
@@ -28,11 +22,6 @@ public class AttributeEnclosingMethod extends Attribute {
     @Override
     public Dumper dump(Dumper d) {
         return d.print("EnclosingMethod");
-    }
-
-    @Override
-    public long getRawByteLength() {
-        return OFFSET_OF_REMAINDER + length;
     }
 
     @Override

--- a/src/org/benf/cfr/reader/entities/attributes/AttributeExceptions.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributeExceptions.java
@@ -12,16 +12,11 @@ import java.util.List;
 public class AttributeExceptions extends Attribute {
     public final static String ATTRIBUTE_NAME = "Exceptions";
 
-    private static final long OFFSET_OF_ATTRIBUTE_LENGTH = 2;
-    private static final long OFFSET_OF_NUMBER_OF_EXCEPTIONS = 6;
-    private static final long OFFSET_OF_EXCEPTION_TABLE = 8;
-    private static final long OFFSET_OF_REMAINDER = 6;
+    private static final long OFFSET_OF_NUMBER_OF_EXCEPTIONS = 0;
+    private static final long OFFSET_OF_EXCEPTION_TABLE = 2;
     private final List<ConstantPoolEntryClass> exceptionClassList = ListFactory.newList();
 
-    private final int length;
-
     public AttributeExceptions(ByteData raw, ConstantPool cp) {
-        this.length = raw.getS4At(OFFSET_OF_ATTRIBUTE_LENGTH);
         int numExceptions = raw.getU2At(OFFSET_OF_NUMBER_OF_EXCEPTIONS);
         long offset = OFFSET_OF_EXCEPTION_TABLE;
         for (int x = 0; x < numExceptions; ++x, offset += 2) {
@@ -48,10 +43,5 @@ public class AttributeExceptions extends Attribute {
 
     public List<ConstantPoolEntryClass> getExceptionClassList() {
         return exceptionClassList;
-    }
-
-    @Override
-    public long getRawByteLength() {
-        return OFFSET_OF_REMAINDER + length;
     }
 }

--- a/src/org/benf/cfr/reader/entities/attributes/AttributeInnerClasses.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributeInnerClasses.java
@@ -16,13 +16,9 @@ import java.util.List;
 public class AttributeInnerClasses extends Attribute {
     public static final String ATTRIBUTE_NAME = "InnerClasses";
 
-    private static final long OFFSET_OF_ATTRIBUTE_LENGTH = 2;
-    private static final long OFFSET_OF_REMAINDER = 6;
-    private static final long OFFSET_OF_NUMBER_OF_CLASSES = 6;
-    private static final long OFFSET_OF_CLASS_ARRAY = 8;
+    private static final long OFFSET_OF_NUMBER_OF_CLASSES = 0;
+    private static final long OFFSET_OF_CLASS_ARRAY = 2;
 
-
-    private final int length;
     private final List<InnerClassAttributeInfo> innerClassAttributeInfoList = ListFactory.newList();
 
     private static JavaTypeInstance getOptClass(int idx, ConstantPool cp) {
@@ -53,7 +49,6 @@ public class AttributeInnerClasses extends Attribute {
     public AttributeInnerClasses(ByteData raw, ConstantPool cp) {
         Boolean forbidMethodScopedClasses = cp.getDCCommonState().getOptions().getOption(OptionsImpl.FORBID_METHOD_SCOPED_CLASSES);
         Boolean forbidAnonymousClasses = cp.getDCCommonState().getOptions().getOption(OptionsImpl.FORBID_ANONYMOUS_CLASSES);
-        this.length = raw.getS4At(OFFSET_OF_ATTRIBUTE_LENGTH);
         int numberInnerClasses = raw.getU2At(OFFSET_OF_NUMBER_OF_CLASSES);
         long offset = OFFSET_OF_CLASS_ARRAY;
         for (int x = 0; x < numberInnerClasses; ++x) {
@@ -98,11 +93,6 @@ public class AttributeInnerClasses extends Attribute {
     @Override
     public Dumper dump(Dumper d) {
         return d.print(ATTRIBUTE_NAME);
-    }
-
-    @Override
-    public long getRawByteLength() {
-        return OFFSET_OF_REMAINDER + length;
     }
 
     public List<InnerClassAttributeInfo> getInnerClassAttributeInfoList() {

--- a/src/org/benf/cfr/reader/entities/attributes/AttributeLineNumberTable.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributeLineNumberTable.java
@@ -9,25 +9,19 @@ import java.util.TreeMap;
 public class AttributeLineNumberTable extends Attribute {
     public static final String ATTRIBUTE_NAME = "LineNumberTable";
 
-    private static final long OFFSET_OF_ATTRIBUTE_LENGTH = 2;
-    private static final long OFFSET_OF_REMAINDER = 6;
-    private static final long OFFSET_OF_ENTRY_COUNT = 6;
-    private static final long OFFSET_OF_ENTRIES = 8;
+    private static final long OFFSET_OF_ENTRY_COUNT = 0;
+    private static final long OFFSET_OF_ENTRIES = 2;
 
-    private final int length;
     private final NavigableMap<Integer, Integer> entries = new TreeMap<Integer, Integer>();
 
 
     public AttributeLineNumberTable(ByteData raw) {
-        this.length = raw.getS4At(OFFSET_OF_ATTRIBUTE_LENGTH);
         int numLineNumbers = raw.getU2At(OFFSET_OF_ENTRY_COUNT);
-        if (numLineNumbers * 2 <= length) {
-            long offset = OFFSET_OF_ENTRIES;
-            for (int x = 0; x < numLineNumbers; ++x, offset += 4) {
-                int startPc = raw.getU2At(offset);
-                int lineNumber = raw.getU2At(offset + 2);
-                entries.put( startPc, lineNumber);
-            }
+        long offset = OFFSET_OF_ENTRIES;
+        for (int x = 0; x < numLineNumbers; ++x, offset += 4) {
+            int startPc = raw.getU2At(offset);
+            int lineNumber = raw.getU2At(offset + 2);
+            entries.put( startPc, lineNumber);
         }
     }
 
@@ -47,11 +41,6 @@ public class AttributeLineNumberTable extends Attribute {
     @Override
     public Dumper dump(Dumper d) {
         return d.print(ATTRIBUTE_NAME);
-    }
-
-    @Override
-    public long getRawByteLength() {
-        return OFFSET_OF_REMAINDER + length;
     }
 
     @Override

--- a/src/org/benf/cfr/reader/entities/attributes/AttributeLocalVariableTable.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributeLocalVariableTable.java
@@ -9,16 +9,11 @@ import java.util.List;
 public class AttributeLocalVariableTable extends Attribute {
     public final static String ATTRIBUTE_NAME = "LocalVariableTable";
 
-    private static final long OFFSET_OF_ATTRIBUTE_LENGTH = 2;
-    private static final long OFFSET_OF_ENTRY_COUNT = 6;
-    private static final long OFFSET_OF_ENTRIES = 8;
-    private static final long OFFSET_OF_REMAINDER = 6;
+    private static final long OFFSET_OF_ENTRY_COUNT = 0;
+    private static final long OFFSET_OF_ENTRIES = 2;
     private final List<LocalVariableEntry> localVariableEntryList = ListFactory.newList();
 
-    private final int length;
-
     public AttributeLocalVariableTable(ByteData raw) {
-        this.length = raw.getS4At(OFFSET_OF_ATTRIBUTE_LENGTH);
         int numLocalVariables = raw.getU2At(OFFSET_OF_ENTRY_COUNT);
         long offset = OFFSET_OF_ENTRIES;
         for (int x = 0; x < numLocalVariables; ++x) {
@@ -44,10 +39,5 @@ public class AttributeLocalVariableTable extends Attribute {
 
     public List<LocalVariableEntry> getLocalVariableEntryList() {
         return localVariableEntryList;
-    }
-
-    @Override
-    public long getRawByteLength() {
-        return OFFSET_OF_REMAINDER + length;
     }
 }

--- a/src/org/benf/cfr/reader/entities/attributes/AttributeLocalVariableTypeTable.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributeLocalVariableTypeTable.java
@@ -1,18 +1,11 @@
 package org.benf.cfr.reader.entities.attributes;
 
-import org.benf.cfr.reader.util.bytestream.ByteData;
 import org.benf.cfr.reader.util.output.Dumper;
 
 public class AttributeLocalVariableTypeTable extends Attribute {
     public final static String ATTRIBUTE_NAME = "LocalVariableTypeTable";
 
-    private static final long OFFSET_OF_ATTRIBUTE_LENGTH = 2;
-    private static final long OFFSET_OF_REMAINDER = 6;
-
-    private final int length;
-
-    public AttributeLocalVariableTypeTable(ByteData raw) {
-        this.length = raw.getS4At(OFFSET_OF_ATTRIBUTE_LENGTH);
+    public AttributeLocalVariableTypeTable() {
     }
 
     @Override
@@ -23,10 +16,5 @@ public class AttributeLocalVariableTypeTable extends Attribute {
     @Override
     public Dumper dump(Dumper d) {
         return d;
-    }
-
-    @Override
-    public long getRawByteLength() {
-        return OFFSET_OF_REMAINDER + length;
     }
 }

--- a/src/org/benf/cfr/reader/entities/attributes/AttributeModule.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributeModule.java
@@ -14,11 +14,10 @@ import java.util.TreeSet;
 public class AttributeModule extends Attribute {
     public static final String ATTRIBUTE_NAME = "Module";
 
-    private static final long OFFSET_OF_ATTRIBUTE_LENGTH = 2;
-    private static final long OFFSET_OF_MODULE_NAME = 6;
-    private static final long OFFSET_OF_MODULE_FLAGS = 8;
-    private static final long OFFSET_OF_MODULE_VERSION = 10;
-    private static final long OFFSET_OF_DYNAMIC_INFO = 12;
+    private static final long OFFSET_OF_MODULE_NAME = 0;
+    private static final long OFFSET_OF_MODULE_FLAGS = 2;
+    private static final long OFFSET_OF_MODULE_VERSION = 4;
+    private static final long OFFSET_OF_DYNAMIC_INFO = 6;
     private final int nameIdx;
     private final int flags;
     private final int versionIdx;
@@ -230,11 +229,9 @@ public class AttributeModule extends Attribute {
 
     // requires, exports, opens, uses and provides are dynamically sized.
 
-    private final int length;
-    private ConstantPool cp;
+    private final ConstantPool cp;
 
     public AttributeModule(ByteData raw, ConstantPool cp) {
-        this.length = raw.getS4At(OFFSET_OF_ATTRIBUTE_LENGTH);
         this.cp = cp;
         this.nameIdx = raw.getU2At(OFFSET_OF_MODULE_NAME);
         this.flags = raw.getU2At(OFFSET_OF_MODULE_FLAGS);
@@ -260,11 +257,6 @@ public class AttributeModule extends Attribute {
     @Override
     public Dumper dump(Dumper d) {
         return d.print(ATTRIBUTE_NAME);
-    }
-
-    @Override
-    public long getRawByteLength() {
-        return OFFSET_OF_MODULE_NAME + length;
     }
 
     @Override

--- a/src/org/benf/cfr/reader/entities/attributes/AttributeModuleClassMain.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributeModuleClassMain.java
@@ -1,18 +1,11 @@
 package org.benf.cfr.reader.entities.attributes;
 
-import org.benf.cfr.reader.util.bytestream.ByteData;
 import org.benf.cfr.reader.util.output.Dumper;
 
 public class AttributeModuleClassMain extends Attribute {
     public static final String ATTRIBUTE_NAME = "ModuleClassMain";
 
-    private static final long OFFSET_OF_ATTRIBUTE_LENGTH = 2;
-    private static final long OFFSET_OF_REMAINDER = 6;
-
-    private final int length;
-
-    public AttributeModuleClassMain(ByteData raw) {
-        this.length = raw.getS4At(OFFSET_OF_ATTRIBUTE_LENGTH);
+    public AttributeModuleClassMain() {
     }
 
     @Override
@@ -23,11 +16,6 @@ public class AttributeModuleClassMain extends Attribute {
     @Override
     public Dumper dump(Dumper d) {
         return d.print(ATTRIBUTE_NAME);
-    }
-
-    @Override
-    public long getRawByteLength() {
-        return OFFSET_OF_REMAINDER + length;
     }
 
     @Override

--- a/src/org/benf/cfr/reader/entities/attributes/AttributeModulePackages.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributeModulePackages.java
@@ -1,18 +1,11 @@
 package org.benf.cfr.reader.entities.attributes;
 
-import org.benf.cfr.reader.util.bytestream.ByteData;
 import org.benf.cfr.reader.util.output.Dumper;
 
 public class AttributeModulePackages extends Attribute {
     public static final String ATTRIBUTE_NAME = "ModulePackages";
 
-    private static final long OFFSET_OF_ATTRIBUTE_LENGTH = 2;
-    private static final long OFFSET_OF_REMAINDER = 6;
-
-    private final int length;
-
-    public AttributeModulePackages(ByteData raw) {
-        this.length = raw.getS4At(OFFSET_OF_ATTRIBUTE_LENGTH);
+    public AttributeModulePackages() {
     }
 
     @Override
@@ -23,11 +16,6 @@ public class AttributeModulePackages extends Attribute {
     @Override
     public Dumper dump(Dumper d) {
         return d.print(ATTRIBUTE_NAME);
-    }
-
-    @Override
-    public long getRawByteLength() {
-        return OFFSET_OF_REMAINDER + length;
     }
 
     @Override

--- a/src/org/benf/cfr/reader/entities/attributes/AttributeParameterAnnotations.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributeParameterAnnotations.java
@@ -13,16 +13,12 @@ import java.util.List;
 
 public abstract class AttributeParameterAnnotations extends Attribute implements TypeUsageCollectable {
 
-    private static final long OFFSET_OF_ATTRIBUTE_LENGTH = 2;
-    private static final long OFFSET_OF_REMAINDER = 6;
-    private static final long OFFSET_OF_NUMBER_OF_PARAMETERS = 6;
-    private static final long OFFSET_OF_ANNOTATION_NAME_TABLE = 7;
+    private static final long OFFSET_OF_NUMBER_OF_PARAMETERS = 0;
+    private static final long OFFSET_OF_ANNOTATION_NAME_TABLE = 1;
 
     private final List<List<AnnotationTableEntry>> annotationTableEntryListList;
-    private final int length;
 
     public AttributeParameterAnnotations(ByteData raw, ConstantPool cp) {
-        this.length = raw.getS4At(OFFSET_OF_ATTRIBUTE_LENGTH);
         byte numParameters = raw.getS1At(OFFSET_OF_NUMBER_OF_PARAMETERS);
         long offset = OFFSET_OF_ANNOTATION_NAME_TABLE;
         annotationTableEntryListList = ListFactory.newList();
@@ -48,11 +44,6 @@ public abstract class AttributeParameterAnnotations extends Attribute implements
     @Override
     public Dumper dump(Dumper d) {
         return d;
-    }
-
-    @Override
-    public long getRawByteLength() {
-        return OFFSET_OF_REMAINDER + length;
     }
 
     @Override

--- a/src/org/benf/cfr/reader/entities/attributes/AttributeParameterAnnotations.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributeParameterAnnotations.java
@@ -19,7 +19,7 @@ public abstract class AttributeParameterAnnotations extends Attribute implements
     private final List<List<AnnotationTableEntry>> annotationTableEntryListList;
 
     public AttributeParameterAnnotations(ByteData raw, ConstantPool cp) {
-        byte numParameters = raw.getS1At(OFFSET_OF_NUMBER_OF_PARAMETERS);
+        short numParameters = raw.getU1At(OFFSET_OF_NUMBER_OF_PARAMETERS);
         long offset = OFFSET_OF_ANNOTATION_NAME_TABLE;
         annotationTableEntryListList = ListFactory.newList();
         for (int x = 0; x < numParameters; ++x) {

--- a/src/org/benf/cfr/reader/entities/attributes/AttributePermittedSubclasses.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributePermittedSubclasses.java
@@ -12,16 +12,12 @@ import java.util.List;
 public class AttributePermittedSubclasses extends Attribute {
     public static final String ATTRIBUTE_NAME = "PermittedSubclasses";
 
-    private static final long OFFSET_OF_ATTRIBUTE_LENGTH = 2;
-    private static final long OFFSET_OF_REMAINDER = 6;
-    private static final long OFFSET_OF_ENTRY_COUNT = 6;
-    private static final long OFFSET_OF_ENTRIES = 8;
+    private static final long OFFSET_OF_ENTRY_COUNT = 0;
+    private static final long OFFSET_OF_ENTRIES = 2;
 
-    private final int length;
     private final List<JavaTypeInstance> entries;
 
     public AttributePermittedSubclasses(ByteData raw, ConstantPool cp) {
-        this.length = raw.getS4At(OFFSET_OF_ATTRIBUTE_LENGTH);
         int numEntries = raw.getU2At(OFFSET_OF_ENTRY_COUNT);
         this.entries = ListFactory.newList();
         long offset = OFFSET_OF_ENTRIES;
@@ -45,11 +41,6 @@ public class AttributePermittedSubclasses extends Attribute {
     @Override
     public Dumper dump(Dumper d) {
         return d.print(ATTRIBUTE_NAME);
-    }
-
-    @Override
-    public long getRawByteLength() {
-        return OFFSET_OF_REMAINDER + length;
     }
 
     @Override

--- a/src/org/benf/cfr/reader/entities/attributes/AttributeRecord.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributeRecord.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import org.benf.cfr.reader.entities.constantpool.ConstantPool;
 import org.benf.cfr.reader.entityfactories.AttributeFactory;
-import org.benf.cfr.reader.entityfactories.ContiguousEntityFactory;
 import org.benf.cfr.reader.util.ClassFileVersion;
 import org.benf.cfr.reader.util.bytestream.ByteData;
 import org.benf.cfr.reader.util.collections.ListFactory;
@@ -13,9 +12,6 @@ import org.benf.cfr.reader.util.output.Dumper;
 
 public class AttributeRecord extends Attribute {
     public static final String ATTRIBUTE_NAME = "Record";
-
-    private static final long OFFSET_OF_ATTRIBUTE_LENGTH = 2;
-    private static final long OFFSET_OF_REMAINDER = 6;
 
     public static class RecordComponentInfo {
         private final String name;
@@ -42,13 +38,11 @@ public class AttributeRecord extends Attribute {
         }
     }
 
-    private final int length;
     private final List<RecordComponentInfo> componentInfos;
 
     public AttributeRecord(ByteData raw, ConstantPool cp, ClassFileVersion classFileVersion) {
-        this.length = raw.getS4At(OFFSET_OF_ATTRIBUTE_LENGTH);
-        int numComponents = raw.getU2At(OFFSET_OF_REMAINDER);
-        long offset = OFFSET_OF_REMAINDER + 2;
+        int numComponents = raw.getU2At(0);
+        long offset = 2;
 
         componentInfos = ListFactory.newList();
         for (int i = 0; i < numComponents; i++) {
@@ -63,10 +57,9 @@ public class AttributeRecord extends Attribute {
             int attributesCount = raw.getS2At(offset);
             offset += 2;
 
-            List<Attribute> attributes = ListFactory.newList();
+            List<Attribute> attributes = ListFactory.newList(attributesCount);
             raw = raw.getOffsetData(offset);
-            offset = ContiguousEntityFactory.build(raw, attributesCount, attributes,
-                    AttributeFactory.getBuilder(cp, classFileVersion));
+            offset = AttributeFactory.readAttributes(raw, cp, classFileVersion, attributesCount, attributes);
 
             componentInfos.add(new RecordComponentInfo(name, descriptor, attributes));
         }
@@ -79,11 +72,6 @@ public class AttributeRecord extends Attribute {
             }
         }
         return Collections.emptyList();
-    }
-
-    @Override
-    public long getRawByteLength() {
-        return OFFSET_OF_REMAINDER + length;
     }
 
     @Override

--- a/src/org/benf/cfr/reader/entities/attributes/AttributeRecord.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributeRecord.java
@@ -46,15 +46,15 @@ public class AttributeRecord extends Attribute {
 
         componentInfos = ListFactory.newList();
         for (int i = 0; i < numComponents; i++) {
-            int nameIndex = raw.getS2At(offset);
+            int nameIndex = raw.getU2At(offset);
             offset += 2;
             String name = cp.getUTF8Entry(nameIndex).getValue();
 
-            int descriptorIndex = raw.getS2At(offset);
+            int descriptorIndex = raw.getU2At(offset);
             offset += 2;
             String descriptor = cp.getUTF8Entry(descriptorIndex).getValue();
 
-            int attributesCount = raw.getS2At(offset);
+            int attributesCount = raw.getU2At(offset);
             offset += 2;
 
             List<Attribute> attributes = ListFactory.newList(attributesCount);

--- a/src/org/benf/cfr/reader/entities/attributes/AttributeScala.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributeScala.java
@@ -1,18 +1,11 @@
 package org.benf.cfr.reader.entities.attributes;
 
-import org.benf.cfr.reader.util.bytestream.ByteData;
 import org.benf.cfr.reader.util.output.Dumper;
 
 public class AttributeScala extends Attribute {
     public final static String ATTRIBUTE_NAME = "Scala";
 
-    private static final long OFFSET_OF_ATTRIBUTE_LENGTH = 2;
-    private static final long OFFSET_OF_REMAINDER = 6;
-
-    private final int length;
-
-    public AttributeScala(ByteData raw) {
-        this.length = raw.getS4At(OFFSET_OF_ATTRIBUTE_LENGTH);
+    public AttributeScala() {
     }
 
     @Override
@@ -23,10 +16,5 @@ public class AttributeScala extends Attribute {
     @Override
     public Dumper dump(Dumper d) {
         return d;
-    }
-
-    @Override
-    public long getRawByteLength() {
-        return OFFSET_OF_REMAINDER + length;
     }
 }

--- a/src/org/benf/cfr/reader/entities/attributes/AttributeScalaSig.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributeScalaSig.java
@@ -1,18 +1,11 @@
 package org.benf.cfr.reader.entities.attributes;
 
-import org.benf.cfr.reader.util.bytestream.ByteData;
 import org.benf.cfr.reader.util.output.Dumper;
 
 public class AttributeScalaSig extends Attribute {
     public final static String ATTRIBUTE_NAME = "ScalaSig";
 
-    private static final long OFFSET_OF_ATTRIBUTE_LENGTH = 2;
-    private static final long OFFSET_OF_REMAINDER = 6;
-
-    private final int length;
-
-    public AttributeScalaSig(ByteData raw) {
-        this.length = raw.getS4At(OFFSET_OF_ATTRIBUTE_LENGTH);
+    public AttributeScalaSig() {
     }
 
     @Override
@@ -23,10 +16,5 @@ public class AttributeScalaSig extends Attribute {
     @Override
     public Dumper dump(Dumper d) {
         return d;
-    }
-
-    @Override
-    public long getRawByteLength() {
-        return OFFSET_OF_REMAINDER + length;
     }
 }

--- a/src/org/benf/cfr/reader/entities/attributes/AttributeSignature.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributeSignature.java
@@ -37,15 +37,10 @@ import org.benf.cfr.reader.util.output.Dumper;
 public class AttributeSignature extends Attribute {
     public static final String ATTRIBUTE_NAME = "Signature";
 
-    private static final long OFFSET_OF_ATTRIBUTE_LENGTH = 2;
-    private static final long OFFSET_OF_REMAINDER = 6;
-
-    private final int length;
     private final ConstantPoolEntryUTF8 signature;
 
     public AttributeSignature(ByteData raw, ConstantPool cp) {
-        this.length = raw.getS4At(OFFSET_OF_ATTRIBUTE_LENGTH);
-        this.signature = cp.getUTF8Entry(raw.getU2At(OFFSET_OF_REMAINDER));
+        this.signature = cp.getUTF8Entry(raw.getU2At(0));
     }
 
     @Override
@@ -56,11 +51,6 @@ public class AttributeSignature extends Attribute {
     @Override
     public Dumper dump(Dumper d) {
         return d.print("Signature : " + signature);
-    }
-
-    @Override
-    public long getRawByteLength() {
-        return OFFSET_OF_REMAINDER + length;
     }
 
     public ConstantPoolEntryUTF8 getSignature() {

--- a/src/org/benf/cfr/reader/entities/attributes/AttributeSourceFile.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributeSourceFile.java
@@ -1,18 +1,11 @@
 package org.benf.cfr.reader.entities.attributes;
 
-import org.benf.cfr.reader.util.bytestream.ByteData;
 import org.benf.cfr.reader.util.output.Dumper;
 
 public class AttributeSourceFile extends Attribute {
     public static final String ATTRIBUTE_NAME = "SourceFile";
 
-    private static final long OFFSET_OF_ATTRIBUTE_LENGTH = 2;
-    private static final long OFFSET_OF_REMAINDER = 6;
-
-    private final int length;
-
-    public AttributeSourceFile(ByteData raw) {
-        this.length = raw.getS4At(OFFSET_OF_ATTRIBUTE_LENGTH);
+    public AttributeSourceFile() {
     }
 
     @Override
@@ -23,11 +16,6 @@ public class AttributeSourceFile extends Attribute {
     @Override
     public Dumper dump(Dumper d) {
         return d.print(ATTRIBUTE_NAME);
-    }
-
-    @Override
-    public long getRawByteLength() {
-        return OFFSET_OF_REMAINDER + length;
     }
 
     @Override

--- a/src/org/benf/cfr/reader/entities/attributes/AttributeStackMapTable.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributeStackMapTable.java
@@ -39,17 +39,13 @@ import java.util.List;
 public class AttributeStackMapTable extends Attribute {
     public final static String ATTRIBUTE_NAME = "StackMapTable";
 
-    private static final long OFFSET_OF_ATTRIBUTE_LENGTH = 2;
-    private static final long OFFSET_OF_REMAINDER = 6;
-    private static final long OFFSET_OF_NUMBER_OF_ENTRIES = OFFSET_OF_REMAINDER;
-    private static final long OFFSET_OF_STACK_MAP_FRAMES = 8;
+    private static final long OFFSET_OF_NUMBER_OF_ENTRIES = 0;
+    private static final long OFFSET_OF_STACK_MAP_FRAMES = 2;
 
-    private final int length;
     private final boolean valid; // apparently, anyway!
     private final List<StackMapFrame> stackMapFrames;
 
     public AttributeStackMapTable(ByteData raw, ConstantPool cp) {
-        this.length = raw.getS4At(OFFSET_OF_ATTRIBUTE_LENGTH);
         this.valid = false;
         this.stackMapFrames = null;
     }
@@ -59,7 +55,6 @@ public class AttributeStackMapTable extends Attribute {
      * memory.
      */
     public AttributeStackMapTable(ByteData raw, ConstantPool cp, ClassFileVersion classFileVersion) {
-        this.length = raw.getS4At(OFFSET_OF_ATTRIBUTE_LENGTH);
         int numEntries = raw.getU2At(OFFSET_OF_NUMBER_OF_ENTRIES);
         long offset = OFFSET_OF_STACK_MAP_FRAMES;
         List<StackMapFrame> frames = ListFactory.newList();
@@ -215,11 +210,6 @@ public class AttributeStackMapTable extends Attribute {
         return d;
     }
 
-    @Override
-    public long getRawByteLength() {
-        return OFFSET_OF_REMAINDER + length;
-    }
-
     private interface StackMapFrame {
     }
 
@@ -309,37 +299,37 @@ public class AttributeStackMapTable extends Attribute {
 
     private static class VerificationInfoTop extends AbstractVerificationInfo {
         private static final char TYPE = 0;
-        private static VerificationInfo INSTANCE = new VerificationInfoTop();
+        private static final VerificationInfo INSTANCE = new VerificationInfoTop();
     }
 
     private static class VerificationInfoInteger extends AbstractVerificationInfo {
         private static final char TYPE = 1;
-        private static VerificationInfo INSTANCE = new VerificationInfoInteger();
+        private static final VerificationInfo INSTANCE = new VerificationInfoInteger();
     }
 
     private static class VerificationInfoFloat extends AbstractVerificationInfo {
         private static final char TYPE = 2;
-        private static VerificationInfo INSTANCE = new VerificationInfoFloat();
+        private static final VerificationInfo INSTANCE = new VerificationInfoFloat();
     }
 
     private static class VerificationInfoDouble extends AbstractVerificationInfo {
         private static final char TYPE = 3;
-        private static VerificationInfo INSTANCE = new VerificationInfoDouble();
+        private static final VerificationInfo INSTANCE = new VerificationInfoDouble();
     }
 
     private static class VerificationInfoLong extends AbstractVerificationInfo {
         private static final char TYPE = 4;
-        private static VerificationInfo INSTANCE = new VerificationInfoLong();
+        private static final VerificationInfo INSTANCE = new VerificationInfoLong();
     }
 
     private static class VerificationInfoNull extends AbstractVerificationInfo {
         private static final char TYPE = 5;
-        private static VerificationInfo INSTANCE = new VerificationInfoNull();
+        private static final VerificationInfo INSTANCE = new VerificationInfoNull();
     }
 
     private static class VerificationInfoUninitializedThis extends AbstractVerificationInfo {
         private static final char TYPE = 6;
-        private static VerificationInfo INSTANCE = new VerificationInfoUninitializedThis();
+        private static final VerificationInfo INSTANCE = new VerificationInfoUninitializedThis();
     }
 
     private static class VerificationInfoObject implements VerificationInfo {

--- a/src/org/benf/cfr/reader/entities/attributes/AttributeSynthetic.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributeSynthetic.java
@@ -1,18 +1,11 @@
 package org.benf.cfr.reader.entities.attributes;
 
-import org.benf.cfr.reader.util.bytestream.ByteData;
 import org.benf.cfr.reader.util.output.Dumper;
 
 public class AttributeSynthetic extends Attribute {
     public final static String ATTRIBUTE_NAME = "Synthetic";
 
-    private static final long OFFSET_OF_ATTRIBUTE_LENGTH = 2;
-    private static final long OFFSET_OF_REMAINDER = 6;
-
-    private final int length;
-
-    public AttributeSynthetic(ByteData raw) {
-        this.length = raw.getS4At(OFFSET_OF_ATTRIBUTE_LENGTH);
+    public AttributeSynthetic() {
     }
 
     @Override
@@ -23,10 +16,5 @@ public class AttributeSynthetic extends Attribute {
     @Override
     public Dumper dump(Dumper d) {
         return d;
-    }
-
-    @Override
-    public long getRawByteLength() {
-        return OFFSET_OF_REMAINDER + length;
     }
 }

--- a/src/org/benf/cfr/reader/entities/attributes/AttributeTypeAnnotations.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributeTypeAnnotations.java
@@ -15,17 +15,11 @@ import java.util.Map;
 
 public abstract class AttributeTypeAnnotations extends Attribute {
 
-    private static final long OFFSET_OF_ATTRIBUTE_LENGTH = 2;
-    private static final long OFFSET_OF_REMAINDER = 6;
-    private static final long OFFSET_OF_NUMBER_OF_ANNOTATIONS = 6;
-    private static final long OFFSET_OF_ANNOTATION_TABLE = 8;
-    private Map<TypeAnnotationEntryValue, List<AnnotationTableTypeEntry>> annotationTableEntryData = MapFactory.newMap();
-
-    private final int length;
-
+    private static final long OFFSET_OF_NUMBER_OF_ANNOTATIONS = 0;
+    private static final long OFFSET_OF_ANNOTATION_TABLE = 2;
+    private final Map<TypeAnnotationEntryValue, List<AnnotationTableTypeEntry>> annotationTableEntryData = MapFactory.newMap();
 
     AttributeTypeAnnotations(ByteData raw, ConstantPool cp) {
-        this.length = raw.getS4At(OFFSET_OF_ATTRIBUTE_LENGTH);
         int numAnnotations = raw.getU2At(OFFSET_OF_NUMBER_OF_ANNOTATIONS);
         long offset = OFFSET_OF_ANNOTATION_TABLE;
 
@@ -53,12 +47,6 @@ public abstract class AttributeTypeAnnotations extends Attribute {
             }
         }
         return d;
-    }
-
-
-    @Override
-    public long getRawByteLength() {
-        return OFFSET_OF_REMAINDER + length;
     }
 
     @Override

--- a/src/org/benf/cfr/reader/entities/attributes/AttributeUnknown.java
+++ b/src/org/benf/cfr/reader/entities/attributes/AttributeUnknown.java
@@ -1,17 +1,11 @@
 package org.benf.cfr.reader.entities.attributes;
 
-import org.benf.cfr.reader.util.bytestream.ByteData;
 import org.benf.cfr.reader.util.output.Dumper;
 
 public class AttributeUnknown extends Attribute {
-    private static final long OFFSET_OF_ATTRIBUTE_LENGTH = 2;
-    private static final long OFFSET_OF_REMAINDER = 6;
-
-    private final int length;
     private final String name;
 
-    public AttributeUnknown(ByteData raw, String name) {
-        this.length = raw.getS4At(OFFSET_OF_ATTRIBUTE_LENGTH);
+    public AttributeUnknown(String name) {
         this.name = name;
     }
 
@@ -23,11 +17,6 @@ public class AttributeUnknown extends Attribute {
     @Override
     public Dumper dump(Dumper d) {
         return d.print("Unknown Attribute : " + name);
-    }
-
-    @Override
-    public long getRawByteLength() {
-        return OFFSET_OF_REMAINDER + length;
     }
 
     @Override

--- a/src/org/benf/cfr/reader/entityfactories/AttributeFactory.java
+++ b/src/org/benf/cfr/reader/entityfactories/AttributeFactory.java
@@ -6,16 +6,17 @@ import org.benf.cfr.reader.entities.attributes.*;
 import org.benf.cfr.reader.util.ClassFileVersion;
 import org.benf.cfr.reader.util.MiscUtils;
 import org.benf.cfr.reader.util.bytestream.ByteData;
-import org.benf.cfr.reader.util.functors.UnaryFunction;
+import org.benf.cfr.reader.util.bytestream.OffsettingByteData;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class AttributeFactory {
     private static final long OFFSET_OF_ATTRIBUTE_NAME_INDEX = 0;
+    private static final long OFFSET_OF_ATTRIBUTE_LENGTH_INDEX = OFFSET_OF_ATTRIBUTE_NAME_INDEX + 2;
+    private static final long OFFSET_OF_ATTRIBUTE_DATA_INDEX = OFFSET_OF_ATTRIBUTE_LENGTH_INDEX + 4;
 
-    public static Attribute build(ByteData raw, ConstantPool cp, ClassFileVersion classFileVersion) {
-        final int nameIndex = raw.getU2At(OFFSET_OF_ATTRIBUTE_NAME_INDEX);
-        ConstantPoolEntryUTF8 name = (ConstantPoolEntryUTF8) cp.getEntry(nameIndex);
-        String attributeName = name.getValue();
-
+    private static Attribute readAttribute(ByteData raw, ConstantPool cp, ClassFileVersion classFileVersion, String attributeName) {
         /*
          * This absolutely could be replaced with a string switch, but I'm sticking to j6,
          * as I want to mandate the minimum sane requirements.
@@ -40,7 +41,7 @@ public class AttributeFactory {
             } else if (AttributeEnclosingMethod.ATTRIBUTE_NAME.equals(attributeName)) {
                 return new AttributeEnclosingMethod(raw);
             } else if (AttributeDeprecated.ATTRIBUTE_NAME.equals(attributeName)) {
-                return new AttributeDeprecated(raw);
+                return new AttributeDeprecated();
             } else if (AttributeRuntimeVisibleAnnotations.ATTRIBUTE_NAME.equals(attributeName)) {
                 return new AttributeRuntimeVisibleAnnotations(raw, cp);
             } else if (AttributeRuntimeVisibleTypeAnnotations.ATTRIBUTE_NAME.equals(attributeName)) {
@@ -54,7 +55,7 @@ public class AttributeFactory {
             } else if (AttributeRuntimeInvisibleParameterAnnotations.ATTRIBUTE_NAME.equals(attributeName)) {
                 return new AttributeRuntimeInvisibleParameterAnnotations(raw, cp);
             } else if (AttributeSourceFile.ATTRIBUTE_NAME.equals(attributeName)) {
-                return new AttributeSourceFile(raw);
+                return new AttributeSourceFile();
             } else if (AttributeInnerClasses.ATTRIBUTE_NAME.equals(attributeName)) {
                 return new AttributeInnerClasses(raw, cp);
             } else if (AttributeBootstrapMethods.ATTRIBUTE_NAME.equals(attributeName)) {
@@ -62,21 +63,21 @@ public class AttributeFactory {
             } else if (AttributeAnnotationDefault.ATTRIBUTE_NAME.equals(attributeName)) {
                 return new AttributeAnnotationDefault(raw, cp);
             } else if (AttributeLocalVariableTypeTable.ATTRIBUTE_NAME.equals(attributeName)) {
-                return new AttributeLocalVariableTypeTable(raw);
+                return new AttributeLocalVariableTypeTable();
             } else if (AttributeStackMapTable.ATTRIBUTE_NAME.equals(attributeName)) {
                 return new AttributeStackMapTable(raw, cp);
             } else if (AttributeSynthetic.ATTRIBUTE_NAME.equals(attributeName)) {
-                return new AttributeSynthetic(raw);
+                return new AttributeSynthetic();
             } else if (AttributeScalaSig.ATTRIBUTE_NAME.equals(attributeName)) {
-                return new AttributeScalaSig(raw);
+                return new AttributeScalaSig();
             } else if (AttributeScala.ATTRIBUTE_NAME.equals(attributeName)) {
-                return new AttributeScala(raw);
+                return new AttributeScala();
             } else if (AttributeModule.ATTRIBUTE_NAME.equals(attributeName)) {
                 return new AttributeModule(raw, cp);
             } else if (AttributeModulePackages.ATTRIBUTE_NAME.equals(attributeName)) {
-                return new AttributeModulePackages(raw);
+                return new AttributeModulePackages();
             } else if (AttributeModuleClassMain.ATTRIBUTE_NAME.equals(attributeName)) {
-                return new AttributeModuleClassMain(raw);
+                return new AttributeModuleClassMain();
             } else if (AttributeRecord.ATTRIBUTE_NAME.equals(attributeName)) {
                 return new AttributeRecord(raw, cp, classFileVersion);
             } else if (AttributePermittedSubclasses.ATTRIBUTE_NAME.equals(attributeName)) {
@@ -86,25 +87,39 @@ public class AttributeFactory {
             // Can't handle it? Continue and process as an unknown attribute.
             MiscUtils.handyBreakPoint();
         }
-        return new AttributeUnknown(raw, attributeName);
+        return new AttributeUnknown(attributeName);
     }
 
-    public static UnaryFunction<ByteData, Attribute> getBuilder(ConstantPool cp, ClassFileVersion classFileVersion) {
-        return new AttributeBuilder(cp, classFileVersion);
+    /**
+     * Reads {@code count} attributes into {@code attributes} and returns the total number of consumed bytes.
+     */
+    public static long readAttributes(ByteData raw, ConstantPool cp, ClassFileVersion classFileVersion, int count, List<Attribute> attributes) {
+        long bytesRead = 0;
+        OffsettingByteData offsettingByteData = raw.getOffsettingOffsetData(0);
+        for (; count > 0; --count) {
+            // All attributes have the same basic structure, see https://docs.oracle.com/javase/specs/jvms/se25/html/jvms-4.html#jvms-4.7
+
+            int nameIndex = offsettingByteData.getU2At(OFFSET_OF_ATTRIBUTE_NAME_INDEX);
+            ConstantPoolEntryUTF8 name = (ConstantPoolEntryUTF8) cp.getEntry(nameIndex);
+            String attributeName = name.getValue();
+
+            long attributeLength = offsettingByteData.getU4At(OFFSET_OF_ATTRIBUTE_LENGTH_INDEX);
+
+            offsettingByteData.advance(OFFSET_OF_ATTRIBUTE_DATA_INDEX);
+            bytesRead += OFFSET_OF_ATTRIBUTE_DATA_INDEX;
+
+            attributes.add(readAttribute(offsettingByteData, cp, classFileVersion, attributeName));
+
+            offsettingByteData.advance(attributeLength);
+            bytesRead += attributeLength;
+        }
+
+        return bytesRead;
     }
 
-    private static class AttributeBuilder implements UnaryFunction<ByteData, Attribute> {
-        private final ConstantPool cp;
-        private final ClassFileVersion classFileVersion;
-
-        AttributeBuilder(ConstantPool cp, ClassFileVersion classFileVersion) {
-            this.cp = cp;
-            this.classFileVersion = classFileVersion;
-        }
-
-        @Override
-        public Attribute invoke(ByteData arg) {
-            return AttributeFactory.build(arg, cp, classFileVersion);
-        }
+    public static List<Attribute> readAttributes(ByteData raw, ConstantPool cp, ClassFileVersion classFileVersion, int count) {
+        List<Attribute> attributes = new ArrayList<Attribute>(count);
+        readAttributes(raw, cp, classFileVersion, count, attributes);
+        return attributes;
     }
 }

--- a/src/org/benf/cfr/reader/util/bytestream/AbstractBackedByteData.java
+++ b/src/org/benf/cfr/reader/util/bytestream/AbstractBackedByteData.java
@@ -22,6 +22,11 @@ public abstract class AbstractBackedByteData implements ByteData {
     }
 
     @Override
+    public long getU4At(long offset) {
+        return getS4At(offset) & 0xFFFFFFFFL;
+    }
+
+    @Override
     public double getDoubleAt(long o) throws ConfusedCFRException {
         return Double.longBitsToDouble(getLongAt(o));
     }

--- a/src/org/benf/cfr/reader/util/bytestream/ByteData.java
+++ b/src/org/benf/cfr/reader/util/bytestream/ByteData.java
@@ -11,6 +11,8 @@ public interface ByteData {
 
     int getS4At(long offset);
 
+    long getU4At(long offset);
+
     double getDoubleAt(long o);
 
     float getFloatAt(long o);


### PR DESCRIPTION
Follow-up for #378

Simplifies the code by moving the common attribute reading logic (name + length) to `AttributeFactory` instead of duplicating it for every attribute class.